### PR TITLE
MODEUS-42 FOLIO-2358 manage container memory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM folioci/openjdk8-jre:latest
+FROM folioci/alpine-jre-openjdk8:latest
 
 ENV VERTICLE_FILE mod-erm-usage-server-fat.jar
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -361,7 +361,7 @@
     },
     "env": [
       { "name": "JAVA_OPTIONS",
-        "value": "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+        "value": "-XX:MaxRAMPercentage=66.0"
       },
       { "name": "DB_HOST", "value": "postgres" },
       { "name": "DB_PORT", "value": "5432" },


### PR DESCRIPTION
Use new Alpine base docker image with more recent Java 8 (222) with +UseContainerSupport, and JAVA_OPTIONS MaxRAMPercentage to manage container memory.

See notes at [FOLIO-2358](https://issues.folio.org/browse/FOLIO-2358).
