### PR TITLE
FOLIO-2405 update base docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mod-erm-usage
 
-Copyright (C) 2018-2019 The Open Library Foundation
+Copyright (C) 2018-2020 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.

--- a/mod-erm-usage-server/Dockerfile
+++ b/mod-erm-usage-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM folioci/openjdk8-jre:latest
+FROM folioci/alpine-jre-openjdk8:latest
 
 ENV VERTICLE_FILE mod-erm-usage-server-fat.jar
 


### PR DESCRIPTION
Utilise the new FOLIO base docker image "folioci/alpine-jre-openjdk8". This has recent Alpine Linux, recent Java 8, and has much smaller size. See [FOLIO-2405](https://issues.folio.org/browse/FOLIO-2405).

The main ./Dockerfile was already updated at [mod-erm-usage/pull/66](https://github.com/folio-org/mod-erm-usage/pull/66)