### PR TITLE
Fix fromVersion of custom-reports in schema.json

### DIFF
--- a/mod-erm-usage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-erm-usage-server/src/main/resources/templates/db_scripts/schema.json
@@ -122,7 +122,7 @@
     },
     {
       "tableName": "custom_reports",
-      "fromModuleVersion": "mod-erm-usage-2.9.0-SNAPSHOT",
+      "fromModuleVersion": "mod-erm-usage-2.10.0-SNAPSHOT",
       "withMetadata": true
     }
   ],


### PR DESCRIPTION
Missed release of 2.9.0, thus schema.json included as fromVersion 2.9.0-SNAPSHOT for table custom-reports.
This commit changes the fromVersion to 2.10.0-SNAPSHOT to be ordered properly.