### PR TITLE
MODEUS-100: Store report types with udp

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "usage-data-providers",
-      "version": "2.5",
+      "version": "2.6",
       "handlers": [
         {
           "methods": [

--- a/ramls/schemas/udprovider.json
+++ b/ramls/schemas/udprovider.json
@@ -163,6 +163,14 @@
         "type": "string"
       }
     },
+    "reportTypes": {
+      "description": "Counter report types of existent reports associated with this UDP",
+      "type": "array",
+      "minItems": 0,
+      "items": {
+        "type": "string"
+      }
+    },
     "harvestingDate": {
       "description": "Date and time of the last harvesting attempt",
       "type": "string",

--- a/ramls/usagedataproviders.raml
+++ b/ramls/usagedataproviders.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Usage Data Providers
-version: v2.5
+version: v2.6
 baseUri: http://localhost/mod-erm-usage
 
 documentation:


### PR DESCRIPTION
In order to filter usage data providers by available reports (see [UIEUS-222](https://issues.folio.org/browse/UIEUS-222)), we need to save names of available reports together with the udp.

This PR adds the property reportTypes to the usage-data-provider schema and a database trigger to keep the list of available reports updated.

Refs. https://issues.folio.org/browse/MODEUS-100