### PR TITLE
Modeus 99 add fields for upload flag

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -125,7 +125,7 @@
     },
     {
       "id": "counter-reports",
-      "version": "2.0",
+      "version": "2.1",
       "handlers": [
         {
           "methods": [

--- a/mod-erm-usage-server/src/test/java/org/folio/rest/impl/CounterReportIT.java
+++ b/mod-erm-usage-server/src/test/java/org/folio/rest/impl/CounterReportIT.java
@@ -220,7 +220,9 @@ public class CounterReportIT {
         .then()
         .contentType(ContentType.JSON)
         .statusCode(200)
-        .body("id", equalTo(report.getId()));
+        .body("id", equalTo(report.getId()))
+        .body("reportEditedManually", equalTo(report.getReportEditedManually()))
+        .body("editReason", equalTo(report.getEditReason()));
 
     // PUT
     given()
@@ -285,7 +287,9 @@ public class CounterReportIT {
         .statusCode(200)
         .body("counterReports.size()", equalTo(1))
         .body("counterReports[0].id", equalTo(report.getId()))
-        .body("counterReports[0].release", equalTo(report.getRelease()));
+        .body("counterReports[0].release", equalTo(report.getRelease()))
+        .body("counterReports[0].reportEditedManually", equalTo(report.getReportEditedManually()))
+        .body("counterReports[0].editReason", equalTo(report.getEditReason()));
 
     String cqlReport2 = "?query=(report=\"someStringThatIsNotInTheReport*\")";
     given()

--- a/ramls/counterreports.raml
+++ b/ramls/counterreports.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Counter Reports
-version: v1.5
+version: v2.1
 baseUri: http://localhost/mod-erm-usage
 
 documentation:

--- a/ramls/examples/counterreport.sample
+++ b/ramls/examples/counterreport.sample
@@ -154,5 +154,7 @@
         "institutionalIdentifier": []
       }
     ]
-  }
+  },
+  "reportEditedManually": true,
+  "editReason": "reason for manually editing"
 }

--- a/ramls/examples/counterreport_collection.sample
+++ b/ramls/examples/counterreport_collection.sample
@@ -7,7 +7,9 @@
     	"release": "4",
     	"reportName": "JR1",
     	"yearMonth": "2018-07",
-    	"report": {}
+    	"report": {},
+    	"reportEditedManually": false,
+      "editReason": ""
     },
     {
     	"id": "8c6b1c02-e153-4413-970b-1b1a3eca1330",
@@ -16,7 +18,9 @@
     	"release": "5",
     	"reportName": "TR_J1",
     	"yearMonth": "2018-07",
-    	"report": {}
+    	"report": {},
+    	"reportEditedManually": true,
+      "editReason": "reason for manually editing"
     }
   ],
   "totalRecords": 2

--- a/ramls/examples/counterreports_sorted.sample
+++ b/ramls/examples/counterreports_sorted.sample
@@ -116,7 +116,9 @@
               "release": "5",
               "reportName": "PR",
               "yearMonth": "2020-01",
-              "providerId": "5aac21f2-1791-4b21-8ae3-f6a9013f42dc"
+              "providerId": "5aac21f2-1791-4b21-8ae3-f6a9013f42dc",
+              "reportEditedManually": true,
+              "editReason": "reason for manually editing"
             }
           ]
         },
@@ -131,7 +133,9 @@
               "release": "5",
               "reportName": "IR",
               "yearMonth": "2020-01",
-              "providerId": "5aac21f2-1791-4b21-8ae3-f6a9013f42dc"
+              "providerId": "5aac21f2-1791-4b21-8ae3-f6a9013f42dc",
+              "reportEditedManually": false,
+              "editReason": ""
             }
           ]
         }

--- a/ramls/schemas/counterreport.json
+++ b/ramls/schemas/counterreport.json
@@ -46,6 +46,14 @@
       "type": "object",
       "$ref": "../raml-util/schemas/metadata.schema",
       "readonly": true
+    },
+    "reportEditedManually": {
+      "description": "Report data has been edited manually",
+      "type": "boolean"
+    },
+    "editReason": {
+      "description": "Edit reason",
+      "type": "string"
     }
   },
   "required": [

--- a/sample-data/counter-reports/2018-01.json
+++ b/sample-data/counter-reports/2018-01.json
@@ -288,5 +288,7 @@
         ]
       }
     ]
-  }
+  },
+  "reportEditedManually": true,
+  "editReason": "reason for manually editing"
 }

--- a/sample-data/counter-reports/2018-02.json
+++ b/sample-data/counter-reports/2018-02.json
@@ -288,5 +288,7 @@
         ]
       }
     ]
-  }
+  },
+  "reportEditedManually": true,
+  "editReason": "another reason for manually editing"
 }

--- a/sample-data/counter-reports/2018-03.json
+++ b/sample-data/counter-reports/2018-03.json
@@ -287,6 +287,8 @@
         "institutionalIdentifier": [
         ]
       }
-    ]
+    ],
+    "reportEditedManually": false,
+    "editReason": ""
   }
 }

--- a/sample-data/counter-reports/2018-04.json
+++ b/sample-data/counter-reports/2018-04.json
@@ -288,5 +288,7 @@
         ]
       }
     ]
-  }
+  },
+  "reportEditedManually": false,
+  "editReason": ""
 }


### PR DESCRIPTION
https://issues.folio.org/browse/MODEUS-99

Users should be able to flag uploaded reports as manually changed and display a small hint in the table. The reason for the edit should be storable.

Example use case:
Data of a reports contains outliers in a certain month, e.g. caused by automatic downloads. The user downloads the report, corrects the data and then uploads it again.
It seems necessary to document both that the data has been edited and what has been the reason for those changes.
In addition, those reports should be easily detectable in the statistics table, if there are serveral months to be edited and the user needs to know what is left to be done.

In this story:

In the upload Counter statistics dialog, two optionla fields need to be added:

1. a checkbox “Report data has been edited manually"
- default: deactivated

2. an input field: “Edit reason"
-  hint: "Enter reason for manual changes"
- If checkbox is deactivated: input field is greyed out/deactivated
-  If checkbox is activated: input field is available
