### PR TITLE
MODEUS-103: Add endpoint to GET available report types

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -225,6 +225,15 @@
           "permissionsRequired": [
             "counterreports.collection.get"
           ]
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "pathPattern": "/counter-reports/reports/types",
+          "permissionsRequired": [
+            "counterreports.collection.get"
+          ]
         }
       ]
     },

--- a/mod-erm-usage-server/src/main/java/org/folio/rest/impl/CounterReportAPI.java
+++ b/mod-erm-usage-server/src/main/java/org/folio/rest/impl/CounterReportAPI.java
@@ -401,6 +401,27 @@ public class CounterReportAPI implements org.folio.rest.jaxrs.resource.CounterRe
             });
   }
 
+  @Override
+  public void getCounterReportsReportsTypes(
+    Map<String, String> okapiHeaders,
+    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    PgHelper.getReportTypes(vertxContext, okapiHeaders)
+      .onComplete(
+        ar -> {
+          if (ar.succeeded()) {
+            org.folio.rest.jaxrs.model.ReportTypes result = ar.result();
+            asyncResultHandler.handle(
+              succeededFuture(
+                GetCounterReportsReportsTypesResponse.respond200WithApplicationJson(
+                  result)));
+          } else {
+            asyncResultHandler.handle(
+              succeededFuture(
+                GetCounterReportsReportsTypesResponse.respond500WithTextPlain(ar.cause())));
+          }
+        });
+  }
+
   private Response createExportResponseByFormat(CounterReport cr, String format) {
     try {
       return csvMapper(cr)

--- a/mod-erm-usage-server/src/main/java/org/folio/rest/impl/CounterReportAPI.java
+++ b/mod-erm-usage-server/src/main/java/org/folio/rest/impl/CounterReportAPI.java
@@ -403,23 +403,24 @@ public class CounterReportAPI implements org.folio.rest.jaxrs.resource.CounterRe
 
   @Override
   public void getCounterReportsReportsTypes(
-    Map<String, String> okapiHeaders,
-    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+      Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler,
+      Context vertxContext) {
     PgHelper.getReportTypes(vertxContext, okapiHeaders)
-      .onComplete(
-        ar -> {
-          if (ar.succeeded()) {
-            org.folio.rest.jaxrs.model.ReportTypes result = ar.result();
-            asyncResultHandler.handle(
-              succeededFuture(
-                GetCounterReportsReportsTypesResponse.respond200WithApplicationJson(
-                  result)));
-          } else {
-            asyncResultHandler.handle(
-              succeededFuture(
-                GetCounterReportsReportsTypesResponse.respond500WithTextPlain(ar.cause())));
-          }
-        });
+        .onComplete(
+            ar -> {
+              if (ar.succeeded()) {
+                org.folio.rest.jaxrs.model.ReportTypes result = ar.result();
+                asyncResultHandler.handle(
+                    succeededFuture(
+                        GetCounterReportsReportsTypesResponse.respond200WithApplicationJson(
+                            result)));
+              } else {
+                asyncResultHandler.handle(
+                    succeededFuture(
+                        GetCounterReportsReportsTypesResponse.respond500WithTextPlain(ar.cause())));
+              }
+            });
   }
 
   private Response createExportResponseByFormat(CounterReport cr, String format) {

--- a/mod-erm-usage-server/src/main/java/org/folio/rest/util/PgHelper.java
+++ b/mod-erm-usage-server/src/main/java/org/folio/rest/util/PgHelper.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -287,7 +288,8 @@ public class PgHelper {
               if (ar.succeeded()) {
                 List<String> collect =
                     StreamSupport.stream(ar.result().spliterator(), false)
-                        .map(row -> Optional.ofNullable(row.getString(0)).orElse("other"))
+                        .map(row -> row.getString(0))
+                        .filter(Objects::nonNull)
                         .collect(Collectors.toList());
                 ReportTypes reportTypes = new ReportTypes().withReportTypes(collect);
                 result.complete(reportTypes);

--- a/mod-erm-usage-server/src/main/java/org/folio/rest/util/PgHelper.java
+++ b/mod-erm-usage-server/src/main/java/org/folio/rest/util/PgHelper.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.folio.rest.jaxrs.model.CounterReport;
 import org.folio.rest.jaxrs.model.ErrorCodes;
+import org.folio.rest.jaxrs.model.ReportTypes;
 import org.folio.rest.jaxrs.model.UsageDataProvider;
 import org.folio.rest.persist.Criteria.Criteria;
 import org.folio.rest.persist.Criteria.Criterion;
@@ -272,6 +273,29 @@ public class PgHelper {
                 result.fail(updateResultAsyncResult.cause());
               }
             });
+    return result.future();
+  }
+
+  public static Future<ReportTypes> getReportTypes(
+    Context vertxContext, Map<String, String> okapiHeaders) {
+    String query =
+      "SELECT DISTINCT(jsonb->>'reportName') FROM counter_reports";
+    Promise<ReportTypes> result = Promise.promise();
+    PgUtil.postgresClient(vertxContext, okapiHeaders)
+      .select(
+        query,
+        ar -> {
+          if (ar.succeeded()) {
+            List<String> collect =
+              StreamSupport.stream(ar.result().spliterator(), false)
+                .map(row -> Optional.ofNullable(row.getString(0)).orElse("other"))
+                .collect(Collectors.toList());
+            ReportTypes reportTypes = new ReportTypes().withReportTypes(collect);
+            result.complete(reportTypes);
+          } else {
+            result.fail(ar.cause());
+          }
+        });
     return result.future();
   }
 }

--- a/mod-erm-usage-server/src/main/java/org/folio/rest/util/PgHelper.java
+++ b/mod-erm-usage-server/src/main/java/org/folio/rest/util/PgHelper.java
@@ -277,25 +277,24 @@ public class PgHelper {
   }
 
   public static Future<ReportTypes> getReportTypes(
-    Context vertxContext, Map<String, String> okapiHeaders) {
-    String query =
-      "SELECT DISTINCT(jsonb->>'reportName') FROM counter_reports";
+      Context vertxContext, Map<String, String> okapiHeaders) {
+    String query = "SELECT DISTINCT(jsonb->>'reportName') FROM counter_reports";
     Promise<ReportTypes> result = Promise.promise();
     PgUtil.postgresClient(vertxContext, okapiHeaders)
-      .select(
-        query,
-        ar -> {
-          if (ar.succeeded()) {
-            List<String> collect =
-              StreamSupport.stream(ar.result().spliterator(), false)
-                .map(row -> Optional.ofNullable(row.getString(0)).orElse("other"))
-                .collect(Collectors.toList());
-            ReportTypes reportTypes = new ReportTypes().withReportTypes(collect);
-            result.complete(reportTypes);
-          } else {
-            result.fail(ar.cause());
-          }
-        });
+        .select(
+            query,
+            ar -> {
+              if (ar.succeeded()) {
+                List<String> collect =
+                    StreamSupport.stream(ar.result().spliterator(), false)
+                        .map(row -> Optional.ofNullable(row.getString(0)).orElse("other"))
+                        .collect(Collectors.toList());
+                ReportTypes reportTypes = new ReportTypes().withReportTypes(collect);
+                result.complete(reportTypes);
+              } else {
+                result.fail(ar.cause());
+              }
+            });
     return result.future();
   }
 }

--- a/mod-erm-usage-server/src/main/resources/templates/db_scripts/custom_indexes.sql
+++ b/mod-erm-usage-server/src/main/resources/templates/db_scripts/custom_indexes.sql
@@ -6,3 +6,6 @@ CREATE INDEX IF NOT EXISTS counter_reports_custom_errorcodes_idx ON counter_repo
   WHERE jsonb ->> 'failedReason' IS NOT NULL;
 CREATE INDEX IF NOT EXISTS usage_data_providers_custom_aggregatorid_idx ON usage_data_providers
   USING btree ((jsonb->'harvestingConfig'->'aggregator'->>'id'));
+CREATE INDEX IF NOT EXISTS counter_reports_custom_reporttypes_idx ON counter_reports
+  USING btree ((jsonb->>'reportName'))
+  WHERE jsonb ->> 'reportName' IS NOT NULL;

--- a/mod-erm-usage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-erm-usage-server/src/main/resources/templates/db_scripts/schema.json
@@ -117,6 +117,10 @@
         },
         {
           "fieldName": "label"
+        },
+        {
+          "fieldName": "reportTypes",
+          "tOps": "ADD"
         }
       ]
     },

--- a/mod-erm-usage-server/src/test/java/org/folio/rest/impl/CounterReportIT.java
+++ b/mod-erm-usage-server/src/test/java/org/folio/rest/impl/CounterReportIT.java
@@ -540,13 +540,10 @@ public class CounterReportIT {
             .header("X-Okapi-Tenant", TENANT)
             .header("content-type", APPLICATION_JSON)
             .header("accept", APPLICATION_JSON)
-            .request()
             .get("/counter-reports/reports/types")
             .thenReturn()
             .as(ReportTypes.class);
-
-    assertThat(reportTypes.getReportTypes().size()).isEqualTo(2);
-    assertThat(reportTypes.getReportTypes()).containsAll(Arrays.asList("TR", "JR1"));
+    assertThat(reportTypes.getReportTypes()).containsExactlyInAnyOrder("TR", "JR1");
 
     // DELETE reports
     given()
@@ -572,5 +569,16 @@ public class CounterReportIT {
         .delete(BASE_URI + "/" + idSecondJR1)
         .then()
         .statusCode(204);
+
+    // GET report types again
+    reportTypes =
+        given()
+            .header("X-Okapi-Tenant", TENANT)
+            .header("content-type", APPLICATION_JSON)
+            .header("accept", APPLICATION_JSON)
+            .get("/counter-reports/reports/types")
+            .thenReturn()
+            .as(ReportTypes.class);
+    assertThat(reportTypes.getReportTypes()).isEmpty();
   }
 }

--- a/mod-erm-usage-server/src/test/java/org/folio/rest/impl/CounterReportIT.java
+++ b/mod-erm-usage-server/src/test/java/org/folio/rest/impl/CounterReportIT.java
@@ -493,82 +493,84 @@ public class CounterReportIT {
   public void checkThatWeGetReportTypes() throws IOException {
     // POST reports
     String trReport =
-      Resources.toString(Resources.getResource("TR/TR_1.json"), StandardCharsets.UTF_8);
-      String idTR = given()
-        .body(trReport)
-        .header(XOkapiHeaders.TENANT, TENANT)
-        .header("content-type", APPLICATION_JSON)
-        .post(BASE_URI)
-        .then()
-        .statusCode(201)
-        .extract()
-        .as(CounterReport.class)
-        .getId();
+        Resources.toString(Resources.getResource("TR/TR_1.json"), StandardCharsets.UTF_8);
+    String idTR =
+        given()
+            .body(trReport)
+            .header(XOkapiHeaders.TENANT, TENANT)
+            .header("content-type", APPLICATION_JSON)
+            .post(BASE_URI)
+            .then()
+            .statusCode(201)
+            .extract()
+            .as(CounterReport.class)
+            .getId();
 
     String firstJr1Report =
-      Resources.toString(Resources.getResource("JR1/jr1_1.json"), StandardCharsets.UTF_8);
-    String idFirstJR1 = given()
-      .body(firstJr1Report)
-      .header(XOkapiHeaders.TENANT, TENANT)
-      .header("content-type", APPLICATION_JSON)
-      .post(BASE_URI)
-      .then()
-      .statusCode(201)
-      .extract()
-      .as(CounterReport.class)
-      .getId();
+        Resources.toString(Resources.getResource("JR1/jr1_1.json"), StandardCharsets.UTF_8);
+    String idFirstJR1 =
+        given()
+            .body(firstJr1Report)
+            .header(XOkapiHeaders.TENANT, TENANT)
+            .header("content-type", APPLICATION_JSON)
+            .post(BASE_URI)
+            .then()
+            .statusCode(201)
+            .extract()
+            .as(CounterReport.class)
+            .getId();
 
     String secondJr1Report =
-      Resources.toString(Resources.getResource("JR1/jr1_2.json"), StandardCharsets.UTF_8);
-    String idSecondJR1 = given()
-      .body(secondJr1Report)
-      .header(XOkapiHeaders.TENANT, TENANT)
-      .header("content-type", APPLICATION_JSON)
-      .post(BASE_URI)
-      .then()
-      .statusCode(201)
-      .extract()
-      .as(CounterReport.class)
-      .getId();
+        Resources.toString(Resources.getResource("JR1/jr1_2.json"), StandardCharsets.UTF_8);
+    String idSecondJR1 =
+        given()
+            .body(secondJr1Report)
+            .header(XOkapiHeaders.TENANT, TENANT)
+            .header("content-type", APPLICATION_JSON)
+            .post(BASE_URI)
+            .then()
+            .statusCode(201)
+            .extract()
+            .as(CounterReport.class)
+            .getId();
 
     // GET report types
     ReportTypes reportTypes =
-      given()
-        .header("X-Okapi-Tenant", TENANT)
-        .header("content-type", APPLICATION_JSON)
-        .header("accept", APPLICATION_JSON)
-        .request()
-        .get("/counter-reports/reports/types")
-        .thenReturn()
-        .as(ReportTypes.class);
+        given()
+            .header("X-Okapi-Tenant", TENANT)
+            .header("content-type", APPLICATION_JSON)
+            .header("accept", APPLICATION_JSON)
+            .request()
+            .get("/counter-reports/reports/types")
+            .thenReturn()
+            .as(ReportTypes.class);
 
     assertThat(reportTypes.getReportTypes().size()).isEqualTo(2);
     assertThat(reportTypes.getReportTypes()).containsAll(Arrays.asList("TR", "JR1"));
 
     // DELETE reports
     given()
-      .header("X-Okapi-Tenant", TENANT)
-      .header("content-type", APPLICATION_JSON)
-      .header("accept", "text/plain")
-      .delete(BASE_URI + "/" + idTR)
-      .then()
-      .statusCode(204);
+        .header("X-Okapi-Tenant", TENANT)
+        .header("content-type", APPLICATION_JSON)
+        .header("accept", "text/plain")
+        .delete(BASE_URI + "/" + idTR)
+        .then()
+        .statusCode(204);
 
     given()
-      .header("X-Okapi-Tenant", TENANT)
-      .header("content-type", APPLICATION_JSON)
-      .header("accept", "text/plain")
-      .delete(BASE_URI + "/" + idFirstJR1)
-      .then()
-      .statusCode(204);
+        .header("X-Okapi-Tenant", TENANT)
+        .header("content-type", APPLICATION_JSON)
+        .header("accept", "text/plain")
+        .delete(BASE_URI + "/" + idFirstJR1)
+        .then()
+        .statusCode(204);
 
     given()
-      .header("X-Okapi-Tenant", TENANT)
-      .header("content-type", APPLICATION_JSON)
-      .header("accept", "text/plain")
-      .delete(BASE_URI + "/" + idSecondJR1)
-      .then()
-      .statusCode(204);
+        .header("X-Okapi-Tenant", TENANT)
+        .header("content-type", APPLICATION_JSON)
+        .header("accept", "text/plain")
+        .delete(BASE_URI + "/" + idSecondJR1)
+        .then()
+        .statusCode(204);
   }
-
 }

--- a/mod-erm-usage-server/src/test/java/org/folio/rest/impl/CounterReportIT.java
+++ b/mod-erm-usage-server/src/test/java/org/folio/rest/impl/CounterReportIT.java
@@ -26,6 +26,7 @@ import org.folio.rest.RestVerticle;
 import org.folio.rest.jaxrs.model.CounterReport;
 import org.folio.rest.jaxrs.model.ErrorCodes;
 import org.folio.rest.jaxrs.model.Report;
+import org.folio.rest.jaxrs.model.ReportTypes;
 import org.folio.rest.jaxrs.model.UsageDataProvider;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.PostgresClient;
@@ -487,4 +488,87 @@ public class CounterReportIT {
         .then()
         .statusCode(204);
   }
+
+  @Test
+  public void checkThatWeGetReportTypes() throws IOException {
+    // POST reports
+    String trReport =
+      Resources.toString(Resources.getResource("TR/TR_1.json"), StandardCharsets.UTF_8);
+      String idTR = given()
+        .body(trReport)
+        .header(XOkapiHeaders.TENANT, TENANT)
+        .header("content-type", APPLICATION_JSON)
+        .post(BASE_URI)
+        .then()
+        .statusCode(201)
+        .extract()
+        .as(CounterReport.class)
+        .getId();
+
+    String firstJr1Report =
+      Resources.toString(Resources.getResource("JR1/jr1_1.json"), StandardCharsets.UTF_8);
+    String idFirstJR1 = given()
+      .body(firstJr1Report)
+      .header(XOkapiHeaders.TENANT, TENANT)
+      .header("content-type", APPLICATION_JSON)
+      .post(BASE_URI)
+      .then()
+      .statusCode(201)
+      .extract()
+      .as(CounterReport.class)
+      .getId();
+
+    String secondJr1Report =
+      Resources.toString(Resources.getResource("JR1/jr1_2.json"), StandardCharsets.UTF_8);
+    String idSecondJR1 = given()
+      .body(secondJr1Report)
+      .header(XOkapiHeaders.TENANT, TENANT)
+      .header("content-type", APPLICATION_JSON)
+      .post(BASE_URI)
+      .then()
+      .statusCode(201)
+      .extract()
+      .as(CounterReport.class)
+      .getId();
+
+    // GET report types
+    ReportTypes reportTypes =
+      given()
+        .header("X-Okapi-Tenant", TENANT)
+        .header("content-type", APPLICATION_JSON)
+        .header("accept", APPLICATION_JSON)
+        .request()
+        .get("/counter-reports/reports/types")
+        .thenReturn()
+        .as(ReportTypes.class);
+
+    assertThat(reportTypes.getReportTypes().size()).isEqualTo(2);
+    assertThat(reportTypes.getReportTypes()).containsAll(Arrays.asList("TR", "JR1"));
+
+    // DELETE reports
+    given()
+      .header("X-Okapi-Tenant", TENANT)
+      .header("content-type", APPLICATION_JSON)
+      .header("accept", "text/plain")
+      .delete(BASE_URI + "/" + idTR)
+      .then()
+      .statusCode(204);
+
+    given()
+      .header("X-Okapi-Tenant", TENANT)
+      .header("content-type", APPLICATION_JSON)
+      .header("accept", "text/plain")
+      .delete(BASE_URI + "/" + idFirstJR1)
+      .then()
+      .statusCode(204);
+
+    given()
+      .header("X-Okapi-Tenant", TENANT)
+      .header("content-type", APPLICATION_JSON)
+      .header("accept", "text/plain")
+      .delete(BASE_URI + "/" + idSecondJR1)
+      .then()
+      .statusCode(204);
+  }
+
 }

--- a/mod-erm-usage-server/src/test/java/org/folio/rest/impl/CounterReportIT.java
+++ b/mod-erm-usage-server/src/test/java/org/folio/rest/impl/CounterReportIT.java
@@ -5,9 +5,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.google.common.io.Resources;
+import com.google.common.net.HttpHeaders;
 import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.http.ContentType;
 import io.restassured.parsing.Parser;
+import io.restassured.specification.RequestSpecification;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
@@ -48,6 +51,7 @@ public class CounterReportIT {
   private static final String APPLICATION_JSON = "application/json";
   private static final String BASE_URI = "/counter-reports";
   private static final String BASE_URI_DOWNLOAD = BASE_URI.concat("/{id}/download");
+  private static final String BASE_URI_REPORT_TYPES = BASE_URI.concat("/reports/types");
   private static final String TENANT = "diku";
   private static final Vertx vertx = Vertx.vertx();
   private static CounterReport report;
@@ -491,14 +495,18 @@ public class CounterReportIT {
 
   @Test
   public void checkThatWeGetReportTypes() throws IOException {
+    RequestSpecification defaultHeaders =
+        new RequestSpecBuilder()
+            .addHeader(XOkapiHeaders.TENANT, TENANT)
+            .addHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)
+            .build();
+
     // POST reports
     String trReport =
         Resources.toString(Resources.getResource("TR/TR_1.json"), StandardCharsets.UTF_8);
     String idTR =
-        given()
+        given(defaultHeaders)
             .body(trReport)
-            .header(XOkapiHeaders.TENANT, TENANT)
-            .header("content-type", APPLICATION_JSON)
             .post(BASE_URI)
             .then()
             .statusCode(201)
@@ -509,10 +517,8 @@ public class CounterReportIT {
     String firstJr1Report =
         Resources.toString(Resources.getResource("JR1/jr1_1.json"), StandardCharsets.UTF_8);
     String idFirstJR1 =
-        given()
+        given(defaultHeaders)
             .body(firstJr1Report)
-            .header(XOkapiHeaders.TENANT, TENANT)
-            .header("content-type", APPLICATION_JSON)
             .post(BASE_URI)
             .then()
             .statusCode(201)
@@ -523,10 +529,8 @@ public class CounterReportIT {
     String secondJr1Report =
         Resources.toString(Resources.getResource("JR1/jr1_2.json"), StandardCharsets.UTF_8);
     String idSecondJR1 =
-        given()
+        given(defaultHeaders)
             .body(secondJr1Report)
-            .header(XOkapiHeaders.TENANT, TENANT)
-            .header("content-type", APPLICATION_JSON)
             .post(BASE_URI)
             .then()
             .statusCode(201)
@@ -536,49 +540,17 @@ public class CounterReportIT {
 
     // GET report types
     ReportTypes reportTypes =
-        given()
-            .header("X-Okapi-Tenant", TENANT)
-            .header("content-type", APPLICATION_JSON)
-            .header("accept", APPLICATION_JSON)
-            .get("/counter-reports/reports/types")
-            .thenReturn()
-            .as(ReportTypes.class);
+        given(defaultHeaders).get(BASE_URI_REPORT_TYPES).thenReturn().as(ReportTypes.class);
     assertThat(reportTypes.getReportTypes()).containsExactlyInAnyOrder("TR", "JR1");
 
     // DELETE reports
-    given()
-        .header("X-Okapi-Tenant", TENANT)
-        .header("content-type", APPLICATION_JSON)
-        .header("accept", "text/plain")
-        .delete(BASE_URI + "/" + idTR)
-        .then()
-        .statusCode(204);
-
-    given()
-        .header("X-Okapi-Tenant", TENANT)
-        .header("content-type", APPLICATION_JSON)
-        .header("accept", "text/plain")
-        .delete(BASE_URI + "/" + idFirstJR1)
-        .then()
-        .statusCode(204);
-
-    given()
-        .header("X-Okapi-Tenant", TENANT)
-        .header("content-type", APPLICATION_JSON)
-        .header("accept", "text/plain")
-        .delete(BASE_URI + "/" + idSecondJR1)
-        .then()
-        .statusCode(204);
+    given(defaultHeaders).delete(BASE_URI + "/" + idTR).then().statusCode(204);
+    given(defaultHeaders).delete(BASE_URI + "/" + idFirstJR1).then().statusCode(204);
+    given(defaultHeaders).delete(BASE_URI + "/" + idSecondJR1).then().statusCode(204);
 
     // GET report types again
     reportTypes =
-        given()
-            .header("X-Okapi-Tenant", TENANT)
-            .header("content-type", APPLICATION_JSON)
-            .header("accept", APPLICATION_JSON)
-            .get("/counter-reports/reports/types")
-            .thenReturn()
-            .as(ReportTypes.class);
+        given(defaultHeaders).get(BASE_URI_REPORT_TYPES).thenReturn().as(ReportTypes.class);
     assertThat(reportTypes.getReportTypes()).isEmpty();
   }
 }

--- a/ramls/counterreports.raml
+++ b/ramls/counterreports.raml
@@ -12,6 +12,7 @@ types:
   counterReports: !include ./schemas/counterreports.json
   counterReportsSorted: !include ./schemas/counterreports_sorted.json
   errorCodes: !include ./schemas/errorcodes.json
+  reportTypes: !include ./schemas/reporttypes.json
   errors: !include ./raml-util/schemas/errors.schema
 
 traits:
@@ -162,6 +163,19 @@ resourceTypes:
             application/json:
               example: !include examples/errorcodes.sample
               schema: errorCodes
+        500:
+          body:
+            text/plain:
+  /reports/types:
+    get:
+      description: Get report types of available counter reports
+      responses:
+        200:
+          description: available report types
+          body:
+            application/json:
+              example: !include examples/reporttypes.sample
+              schema: reportTypes
         500:
           body:
             text/plain:

--- a/ramls/examples/reporttypes.sample
+++ b/ramls/examples/reporttypes.sample
@@ -1,0 +1,3 @@
+{
+  "reportTypes": ["DR", "PR", "TR"]
+}

--- a/ramls/schemas/reporttypes.json
+++ b/ramls/schemas/reporttypes.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "List of available counter report types",
+  "properties": {
+    "reportTypes": {
+      "description": "Available report types",
+      "type": "array",
+      "minItems": 0,
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "reportTypes"
+  ]
+}


### PR DESCRIPTION
In order to filter usage data providers by available reports (see [UIEUS-222](https://issues.folio.org/browse/UIEUS-222)) we need to fetch all available report types.

This PR adds an endpoint to get all available report types.

Refs. https://issues.folio.org/browse/MODEUS-103