### PR TITLE
MODEUS-104: Restructure counter reports

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -125,7 +125,7 @@
     },
     {
       "id": "counter-reports",
-      "version": "2.1",
+      "version": "3.0",
       "handlers": [
         {
           "methods": [

--- a/mod-erm-usage-client/pom.xml
+++ b/mod-erm-usage-client/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.olf</groupId>
     <artifactId>mod-erm-usage</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/mod-erm-usage-server/pom.xml
+++ b/mod-erm-usage-server/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.olf</groupId>
     <artifactId>mod-erm-usage</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/mod-erm-usage-server/src/main/java/org/folio/rest/util/UploadHelper.java
+++ b/mod-erm-usage-server/src/main/java/org/folio/rest/util/UploadHelper.java
@@ -3,14 +3,11 @@ package org.folio.rest.util;
 import com.google.gson.Gson;
 import io.vertx.core.json.Json;
 import java.io.IOException;
-import java.io.InputStream;
 import java.time.YearMonth;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import org.apache.commons.codec.Charsets;
-import org.apache.commons.io.IOUtils;
 import org.folio.rest.jaxrs.model.CounterReport;
 import org.niso.schemas.counter.Report;
 import org.olf.erm.usage.counter41.Counter4Utils;
@@ -28,14 +25,8 @@ public class UploadHelper {
 
   private static final String MSG_WRONG_FORMAT = "Wrong format supplied";
 
-  public static List<CounterReport> getCounterReportsFromInputStream(InputStream entity)
-      throws FileUploadException, ReportSplitException, Counter5UtilsException {
-    String content;
-    try {
-      content = IOUtils.toString(entity, Charsets.UTF_8);
-    } catch (Exception e) {
-      throw new FileUploadException(e);
-    }
+  public static List<CounterReport> getCounterReportsFromString(String content)
+      throws FileUploadException, Counter5UtilsException, ReportSplitException {
     String release = getCounterRelease(content);
 
     List<CounterReport> counterReports;
@@ -191,5 +182,6 @@ public class UploadHelper {
     }
   }
 
-  private UploadHelper() {}
+  private UploadHelper() {
+  }
 }

--- a/mod-erm-usage-server/src/test/java/org/folio/rest/impl/CounterReportUploadIT.java
+++ b/mod-erm-usage-server/src/test/java/org/folio/rest/impl/CounterReportUploadIT.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.hamcrest.Matchers.containsString;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Files;
 import com.google.common.io.Resources;
 import com.google.common.net.HttpHeaders;
@@ -25,6 +26,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -33,8 +35,11 @@ import org.apache.commons.io.IOUtils;
 import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.client.TenantClient;
+import org.folio.rest.jaxrs.model.Contents;
 import org.folio.rest.jaxrs.model.CounterReport;
+import org.folio.rest.jaxrs.model.CounterReportDocument;
 import org.folio.rest.jaxrs.model.CounterReports;
+import org.folio.rest.jaxrs.model.ReportMetadata;
 import org.folio.rest.jaxrs.model.TenantAttributes;
 import org.folio.rest.jaxrs.model.UsageDataProvider;
 import org.folio.rest.persist.Criteria.Criterion;
@@ -83,7 +88,8 @@ public class CounterReportUploadIT {
   private static final File FILE_REPORT5_OK =
       new File(Resources.getResource("fileupload/hwire_trj1.json").getFile());
   private static Vertx vertx;
-  @Rule public Timeout timeout = Timeout.seconds(10);
+  @Rule
+  public Timeout timeout = Timeout.seconds(10);
 
   @BeforeClass
   public static void setUp(TestContext context) {
@@ -204,12 +210,42 @@ public class CounterReportUploadIT {
     testThatDBSizeIsSize(0);
   }
 
+  private String createReportFromJson(File jsonFile)
+      throws IOException {
+    return createReport(jsonFile, "application/json", false, null);
+  }
+
+  private String createReport(File file, String mimeType, Boolean reportEditedManually,
+      String editReason)
+      throws IOException {
+    String fileAsString = Files.toString(file, StandardCharsets.UTF_8);
+    return createReport(fileAsString, mimeType, reportEditedManually, editReason);
+  }
+
+  private String createReport(String string, String mimeType, Boolean reportEditedManually,
+      String editReason)
+      throws IOException {
+    String fileAsBytes = Base64.getEncoder().encodeToString(string.getBytes());
+    Contents content = new Contents().withData("data:" + mimeType + " ;base64," + fileAsBytes);
+    ReportMetadata metadata = new ReportMetadata().withReportEditedManually(reportEditedManually);
+    if (editReason != null && reportEditedManually) {
+      metadata.setEditReason(editReason);
+    }
+    CounterReportDocument document = new CounterReportDocument()
+        .withReportMetadata(metadata)
+        .withContents(content);
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    return objectMapper.writeValueAsString(document);
+  }
+
   @Test
-  public void testReportR4Ok() {
+  public void testReportR4Ok() throws IOException {
+    String report = createReportFromJson(FILE_REPORT_OK);
     String savedReportId =
         given()
             .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
-            .body(FILE_REPORT_OK)
+            .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
             .post("/counter-reports/upload/provider/" + PROVIDER_ID)
             .then()
             .statusCode(200)
@@ -232,10 +268,38 @@ public class CounterReportUploadIT {
   }
 
   @Test
-  public void testReportR4UnsupportedReport() {
+  public void testReportR4OkWithEditReason() throws IOException {
+    String report = createReport(FILE_REPORT_OK, "application/json", true, "Edit Reason");
+    String savedReportId =
+        given()
+            .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
+            .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
+            .post("/counter-reports/upload/provider/" + PROVIDER_ID)
+            .then()
+            .statusCode(200)
+            .body(containsString("Saved report"))
+            .extract()
+            .asString()
+            .replace("Saved report with ids: ", "");
+
+    CounterReport savedReport =
+        given().get("/counter-reports/" + savedReportId).then().extract().as(CounterReport.class);
+    assertThat(savedReport.getProviderId()).isEqualTo(PROVIDER_ID);
+    assertThat(savedReport.getRelease()).isEqualTo("4");
+    assertThat(savedReport.getReportEditedManually()).isTrue();
+    assertThat(savedReport.getEditReason()).isEqualTo("Edit Reason");
+
+    Report reportFromXML = JAXB.unmarshal(FILE_REPORT_OK, Report.class);
+    Report reportFromDB = Counter4Utils.fromJSON(Json.encode(savedReport.getReport()));
+    assertThat(reportFromXML).usingRecursiveComparison().isEqualTo(reportFromDB);
+  }
+
+  @Test
+  public void testReportR4UnsupportedReport() throws IOException {
+    String report = createReportFromJson(FILE_REPORT_UNSUPPORTED);
     given()
         .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
-        .body(FILE_REPORT_UNSUPPORTED)
+        .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
         .post("/counter-reports/upload/provider/" + PROVIDER_ID)
         .then()
         .statusCode(500)
@@ -243,11 +307,12 @@ public class CounterReportUploadIT {
   }
 
   @Test
-  public void testReportR4OkOverwriteTrue() {
+  public void testReportR4OkOverwriteTrue() throws IOException {
+    String report = createReportFromJson(FILE_REPORT_OK);
     String savedReportId =
         given()
             .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
-            .body(FILE_REPORT_OK)
+            .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
             .queryParam("overwrite", true)
             .post("/counter-reports/upload/provider/" + PROVIDER_ID)
             .then()
@@ -259,7 +324,7 @@ public class CounterReportUploadIT {
     String overwriteReportId =
         given()
             .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
-            .body(FILE_REPORT_OK)
+            .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
             .queryParam("overwrite", true)
             .post("/counter-reports/upload/provider/" + PROVIDER_ID)
             .then()
@@ -272,10 +337,11 @@ public class CounterReportUploadIT {
   }
 
   @Test
-  public void testReportR4OkOverwriteFalse() {
+  public void testReportR4OkOverwriteFalse() throws IOException {
+    String report = createReportFromJson(FILE_REPORT_OK);
     given()
         .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
-        .body(FILE_REPORT_OK)
+        .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
         .queryParam("overwrite", false)
         .post("/counter-reports/upload/provider/" + PROVIDER_ID)
         .then()
@@ -283,7 +349,7 @@ public class CounterReportUploadIT {
 
     given()
         .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
-        .body(FILE_REPORT_OK)
+        .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
         .queryParam("overwrite", false)
         .post("/counter-reports/upload/provider/" + PROVIDER_ID)
         .then()
@@ -293,11 +359,12 @@ public class CounterReportUploadIT {
   }
 
   @Test
-  public void testReportR4NssOk() {
+  public void testReportR4NssOk() throws IOException {
+    String report = createReportFromJson(FILE_REPORT_NSS_OK);
     String savedReportId =
         given()
             .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
-            .body(FILE_REPORT_NSS_OK)
+            .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
             .post("/counter-reports/upload/provider/" + PROVIDER_ID)
             .then()
             .statusCode(200)
@@ -325,10 +392,11 @@ public class CounterReportUploadIT {
 
   @Test
   public void testReportR5Ok() throws Exception {
+    String reportDoc = createReportFromJson(FILE_REPORT5_OK);
     String savedReportId =
         given()
             .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
-            .body(FILE_REPORT5_OK)
+            .body(IOUtils.toInputStream(reportDoc, StandardCharsets.UTF_8))
             .post("/counter-reports/upload/provider/" + PROVIDER_ID)
             .then()
             .statusCode(200)
@@ -353,10 +421,11 @@ public class CounterReportUploadIT {
   }
 
   @Test
-  public void testReportInvalidContent() {
+  public void testReportInvalidContent() throws IOException {
+    String report = createReportFromJson(FILE_NO_REPORT);
     given()
         .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
-        .body(FILE_NO_REPORT)
+        .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
         .post("/counter-reports/upload/provider/" + PROVIDER_ID)
         .then()
         .statusCode(500)
@@ -364,11 +433,12 @@ public class CounterReportUploadIT {
   }
 
   @Test
-  public void testReportMultipleMonthsC4() {
+  public void testReportMultipleMonthsC4() throws IOException {
+    String report = createReportFromJson(FILE_REPORT_MULTI_COP4);
     String createdIds =
         given()
             .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
-            .body(FILE_REPORT_MULTI_COP4)
+            .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
             .post("/counter-reports/upload/provider/" + PROVIDER_ID)
             .then()
             .statusCode(200)
@@ -387,7 +457,7 @@ public class CounterReportUploadIT {
 
     given()
         .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
-        .body(FILE_REPORT_MULTI_COP4)
+        .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
         .post("/counter-reports/upload/provider/" + PROVIDER_ID)
         .then()
         .statusCode(500)
@@ -413,10 +483,11 @@ public class CounterReportUploadIT {
     String csvString = Counter4Utils.toCSV(JAXB.unmarshal(FILE_REPORT_MULTI_COP4, Report.class));
     assertThat(csvString).isNotNull();
 
+    String reportDocument = createReport(csvString, "text/csv", false, null);
     String createdIds =
         given()
             .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
-            .body(IOUtils.toInputStream(csvString, StandardCharsets.UTF_8))
+            .body(IOUtils.toInputStream(reportDocument, StandardCharsets.UTF_8))
             .post("/counter-reports/upload/provider/" + PROVIDER_ID)
             .then()
             .statusCode(200)
@@ -462,9 +533,10 @@ public class CounterReportUploadIT {
         .ignoringCollectionOrder()
         .isEqualTo(expectedReports.get(1));
 
+    String reportDocumentCOP4 = createReportFromJson(FILE_REPORT_MULTI_COP4);
     given()
         .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
-        .body(FILE_REPORT_MULTI_COP4)
+        .body(IOUtils.toInputStream(reportDocumentCOP4, StandardCharsets.UTF_8))
         .post("/counter-reports/upload/provider/" + PROVIDER_ID)
         .then()
         .statusCode(500)
@@ -474,11 +546,12 @@ public class CounterReportUploadIT {
   }
 
   @Test
-  public void testReportMultipleMonthsC5() {
+  public void testReportMultipleMonthsC5() throws IOException {
+    String reportDoc = createReportFromJson(FILE_REPORT_MULTI_COP5);
     String createdIds =
         given()
             .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
-            .body(FILE_REPORT_MULTI_COP5)
+            .body(IOUtils.toInputStream(reportDoc, StandardCharsets.UTF_8))
             .post("/counter-reports/upload/provider/" + PROVIDER_ID)
             .then()
             .statusCode(200)
@@ -497,7 +570,7 @@ public class CounterReportUploadIT {
 
     given()
         .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
-        .body(FILE_REPORT_MULTI_COP5)
+        .body(IOUtils.toInputStream(reportDoc, StandardCharsets.UTF_8))
         .post("/counter-reports/upload/provider/" + PROVIDER_ID)
         .then()
         .statusCode(500)
@@ -517,10 +590,11 @@ public class CounterReportUploadIT {
     String csvString = Counter5Utils.toCSV(report);
     assertThat(csvString).isNotNull();
 
+    String reportDoc = createReport(csvString, "text/csv", false, null);
     String createdIds =
         given()
             .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
-            .body(IOUtils.toInputStream(csvString, StandardCharsets.UTF_8))
+            .body(IOUtils.toInputStream(reportDoc, StandardCharsets.UTF_8))
             .post("/counter-reports/upload/provider/" + PROVIDER_ID)
             .then()
             .statusCode(200)
@@ -555,9 +629,10 @@ public class CounterReportUploadIT {
     compareCOP5Reports(actualReports, expectedReports, 1);
     compareCOP5Reports(actualReports, expectedReports, 2);
 
+    String reportDocFromJSON = createReportFromJson(FILE_REPORT_MULTI_COP5);
     given()
         .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
-        .body(FILE_REPORT_MULTI_COP5)
+        .body(IOUtils.toInputStream(reportDocFromJSON, StandardCharsets.UTF_8))
         .post("/counter-reports/upload/provider/" + PROVIDER_ID)
         .then()
         .statusCode(500)
@@ -565,6 +640,48 @@ public class CounterReportUploadIT {
         .body(containsString("2019-09"))
         .body(containsString("2019-10"))
         .body(containsString("2019-11"));
+  }
+
+  @Test
+  public void testReportMultipleMonthsC5FromCsvWithEditReason()
+      throws IOException, Counter5UtilsException {
+    String jsonString =
+        Resources.toString(FILE_REPORT_MULTI_COP5.toURI().toURL(), StandardCharsets.UTF_8);
+    assertThat(jsonString).isNotNull();
+
+    Object report = Counter5Utils.fromJSON(jsonString);
+    String csvString = Counter5Utils.toCSV(report);
+    assertThat(csvString).isNotNull();
+
+    String reportDoc = createReport(csvString, "text/csv", true, "Edit Reason");
+    String createdIds =
+        given()
+            .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
+            .body(IOUtils.toInputStream(reportDoc, StandardCharsets.UTF_8))
+            .post("/counter-reports/upload/provider/" + PROVIDER_ID)
+            .then()
+            .statusCode(200)
+            .body(containsString("Saved report with ids"))
+            .extract()
+            .asString()
+            .replace("Saved report with ids: ", "");
+
+    String query =
+        String.format(
+            "/counter-reports?query=(reportName=TR AND providerId=%s) sortby yearMonth",
+            PROVIDER_ID);
+    CounterReports reports = given().get(query).then().extract().as(CounterReports.class);
+    assertThat(reports.getCounterReports().stream().map(CounterReport::getYearMonth))
+        .containsExactly("2019-09", "2019-10", "2019-11");
+    assertThat(reports.getCounterReports().stream().map(CounterReport::getId))
+        .containsExactly(createdIds.split(","));
+
+    // check content here
+    assertThat(report).isNotNull();
+    reports.getCounterReports().forEach(counterReport -> {
+      assertThat(counterReport.getReportEditedManually()).isTrue();
+      assertThat(counterReport.getEditReason()).isEqualTo("Edit Reason");
+    });
   }
 
   private void compareCOP5Reports(
@@ -640,10 +757,11 @@ public class CounterReportUploadIT {
   }
 
   @Test
-  public void testProviderNotFound() {
+  public void testProviderNotFound() throws IOException {
+    String reportDoc = createReportFromJson(FILE_REPORT_OK);
     given()
         .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
-        .body(FILE_REPORT_OK)
+        .body(IOUtils.toInputStream(reportDoc, StandardCharsets.UTF_8))
         .post("/counter-reports/upload/provider/" + PROVIDER_ID2)
         .then()
         .statusCode(500)

--- a/mod-erm-usage-server/src/test/java/org/folio/rest/impl/CounterReportUploadIT.java
+++ b/mod-erm-usage-server/src/test/java/org/folio/rest/impl/CounterReportUploadIT.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.hamcrest.Matchers.containsString;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Files;
 import com.google.common.io.Resources;
 import com.google.common.net.HttpHeaders;
@@ -31,7 +30,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import javax.xml.bind.JAXB;
-import org.apache.commons.io.IOUtils;
 import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.client.TenantClient;
@@ -88,8 +86,7 @@ public class CounterReportUploadIT {
   private static final File FILE_REPORT5_OK =
       new File(Resources.getResource("fileupload/hwire_trj1.json").getFile());
   private static Vertx vertx;
-  @Rule
-  public Timeout timeout = Timeout.seconds(10);
+  @Rule public Timeout timeout = Timeout.seconds(10);
 
   @BeforeClass
   public static void setUp(TestContext context) {
@@ -210,19 +207,18 @@ public class CounterReportUploadIT {
     testThatDBSizeIsSize(0);
   }
 
-  private String createReportFromJson(File jsonFile)
-      throws IOException {
+  private CounterReportDocument createReportFromJson(File jsonFile) throws IOException {
     return createReport(jsonFile, "application/json", false, null);
   }
 
-  private String createReport(File file, String mimeType, Boolean reportEditedManually,
-      String editReason)
+  private CounterReportDocument createReport(
+      File file, String mimeType, Boolean reportEditedManually, String editReason)
       throws IOException {
     String fileAsString = Files.toString(file, StandardCharsets.UTF_8);
     return createReport(fileAsString, mimeType, reportEditedManually, editReason);
   }
 
-private CounterReportDocument createReport(
+  private CounterReportDocument createReport(
       String string, String mimeType, Boolean reportEditedManually, String editReason) {
     String fileAsBytes = Base64.getEncoder().encodeToString(string.getBytes());
     Contents content = new Contents().withData("data:" + mimeType + " ;base64," + fileAsBytes);
@@ -235,11 +231,11 @@ private CounterReportDocument createReport(
 
   @Test
   public void testReportR4Ok() throws IOException {
-    String report = createReportFromJson(FILE_REPORT_OK);
+    CounterReportDocument report = createReportFromJson(FILE_REPORT_OK);
     String savedReportId =
         given()
             .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
-            .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
+            .body(report)
             .post("/counter-reports/upload/provider/" + PROVIDER_ID)
             .then()
             .statusCode(200)
@@ -263,11 +259,12 @@ private CounterReportDocument createReport(
 
   @Test
   public void testReportR4OkWithEditReason() throws IOException {
-    String report = createReport(FILE_REPORT_OK, "application/json", true, "Edit Reason");
+    CounterReportDocument report =
+        createReport(FILE_REPORT_OK, "application/json", true, "Edit Reason");
     String savedReportId =
         given()
             .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
-            .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
+            .body(report)
             .post("/counter-reports/upload/provider/" + PROVIDER_ID)
             .then()
             .statusCode(200)
@@ -290,10 +287,10 @@ private CounterReportDocument createReport(
 
   @Test
   public void testReportR4UnsupportedReport() throws IOException {
-    String report = createReportFromJson(FILE_REPORT_UNSUPPORTED);
+    CounterReportDocument report = createReportFromJson(FILE_REPORT_UNSUPPORTED);
     given()
         .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
-        .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
+        .body(report)
         .post("/counter-reports/upload/provider/" + PROVIDER_ID)
         .then()
         .statusCode(400)
@@ -302,11 +299,11 @@ private CounterReportDocument createReport(
 
   @Test
   public void testReportR4OkOverwriteTrue() throws IOException {
-    String report = createReportFromJson(FILE_REPORT_OK);
+    CounterReportDocument report = createReportFromJson(FILE_REPORT_OK);
     String savedReportId =
         given()
             .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
-            .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
+            .body(report)
             .queryParam("overwrite", true)
             .post("/counter-reports/upload/provider/" + PROVIDER_ID)
             .then()
@@ -318,7 +315,7 @@ private CounterReportDocument createReport(
     String overwriteReportId =
         given()
             .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
-            .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
+            .body(report)
             .queryParam("overwrite", true)
             .post("/counter-reports/upload/provider/" + PROVIDER_ID)
             .then()
@@ -332,10 +329,10 @@ private CounterReportDocument createReport(
 
   @Test
   public void testReportR4OkOverwriteFalse() throws IOException {
-    String report = createReportFromJson(FILE_REPORT_OK);
+    CounterReportDocument report = createReportFromJson(FILE_REPORT_OK);
     given()
         .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
-        .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
+        .body(report)
         .queryParam("overwrite", false)
         .post("/counter-reports/upload/provider/" + PROVIDER_ID)
         .then()
@@ -343,7 +340,7 @@ private CounterReportDocument createReport(
 
     given()
         .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
-        .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
+        .body(report)
         .queryParam("overwrite", false)
         .post("/counter-reports/upload/provider/" + PROVIDER_ID)
         .then()
@@ -354,11 +351,11 @@ private CounterReportDocument createReport(
 
   @Test
   public void testReportR4NssOk() throws IOException {
-    String report = createReportFromJson(FILE_REPORT_NSS_OK);
+    CounterReportDocument report = createReportFromJson(FILE_REPORT_NSS_OK);
     String savedReportId =
         given()
             .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
-            .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
+            .body(report)
             .post("/counter-reports/upload/provider/" + PROVIDER_ID)
             .then()
             .statusCode(200)
@@ -386,11 +383,11 @@ private CounterReportDocument createReport(
 
   @Test
   public void testReportR5Ok() throws Exception {
-    String reportDoc = createReportFromJson(FILE_REPORT5_OK);
+    CounterReportDocument reportDoc = createReportFromJson(FILE_REPORT5_OK);
     String savedReportId =
         given()
             .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
-            .body(IOUtils.toInputStream(reportDoc, StandardCharsets.UTF_8))
+            .body(reportDoc)
             .post("/counter-reports/upload/provider/" + PROVIDER_ID)
             .then()
             .statusCode(200)
@@ -416,10 +413,10 @@ private CounterReportDocument createReport(
 
   @Test
   public void testReportInvalidContent() throws IOException {
-    String report = createReportFromJson(FILE_NO_REPORT);
+    CounterReportDocument report = createReportFromJson(FILE_NO_REPORT);
     given()
         .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
-        .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
+        .body(report)
         .post("/counter-reports/upload/provider/" + PROVIDER_ID)
         .then()
         .statusCode(400)
@@ -428,11 +425,11 @@ private CounterReportDocument createReport(
 
   @Test
   public void testReportMultipleMonthsC4() throws IOException {
-    String report = createReportFromJson(FILE_REPORT_MULTI_COP4);
+    CounterReportDocument report = createReportFromJson(FILE_REPORT_MULTI_COP4);
     String createdIds =
         given()
             .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
-            .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
+            .body(report)
             .post("/counter-reports/upload/provider/" + PROVIDER_ID)
             .then()
             .statusCode(200)
@@ -451,7 +448,7 @@ private CounterReportDocument createReport(
 
     given()
         .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
-        .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
+        .body(report)
         .post("/counter-reports/upload/provider/" + PROVIDER_ID)
         .then()
         .statusCode(500)
@@ -477,11 +474,11 @@ private CounterReportDocument createReport(
     String csvString = Counter4Utils.toCSV(JAXB.unmarshal(FILE_REPORT_MULTI_COP4, Report.class));
     assertThat(csvString).isNotNull();
 
-    String reportDocument = createReport(csvString, "text/csv", false, null);
+    CounterReportDocument reportDocument = createReport(csvString, "text/csv", false, null);
     String createdIds =
         given()
             .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
-            .body(IOUtils.toInputStream(reportDocument, StandardCharsets.UTF_8))
+            .body(reportDocument)
             .post("/counter-reports/upload/provider/" + PROVIDER_ID)
             .then()
             .statusCode(200)
@@ -527,10 +524,10 @@ private CounterReportDocument createReport(
         .ignoringCollectionOrder()
         .isEqualTo(expectedReports.get(1));
 
-    String reportDocumentCOP4 = createReportFromJson(FILE_REPORT_MULTI_COP4);
+    CounterReportDocument reportDocumentCOP4 = createReportFromJson(FILE_REPORT_MULTI_COP4);
     given()
         .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
-        .body(IOUtils.toInputStream(reportDocumentCOP4, StandardCharsets.UTF_8))
+        .body(reportDocumentCOP4)
         .post("/counter-reports/upload/provider/" + PROVIDER_ID)
         .then()
         .statusCode(500)
@@ -541,11 +538,11 @@ private CounterReportDocument createReport(
 
   @Test
   public void testReportMultipleMonthsC5() throws IOException {
-    String reportDoc = createReportFromJson(FILE_REPORT_MULTI_COP5);
+    CounterReportDocument reportDoc = createReportFromJson(FILE_REPORT_MULTI_COP5);
     String createdIds =
         given()
             .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
-            .body(IOUtils.toInputStream(reportDoc, StandardCharsets.UTF_8))
+            .body(reportDoc)
             .post("/counter-reports/upload/provider/" + PROVIDER_ID)
             .then()
             .statusCode(200)
@@ -564,7 +561,7 @@ private CounterReportDocument createReport(
 
     given()
         .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
-        .body(IOUtils.toInputStream(reportDoc, StandardCharsets.UTF_8))
+        .body(reportDoc)
         .post("/counter-reports/upload/provider/" + PROVIDER_ID)
         .then()
         .statusCode(500)
@@ -584,11 +581,11 @@ private CounterReportDocument createReport(
     String csvString = Counter5Utils.toCSV(report);
     assertThat(csvString).isNotNull();
 
-    String reportDoc = createReport(csvString, "text/csv", false, null);
+    CounterReportDocument reportDoc = createReport(csvString, "text/csv", false, null);
     String createdIds =
         given()
             .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
-            .body(IOUtils.toInputStream(reportDoc, StandardCharsets.UTF_8))
+            .body(reportDoc)
             .post("/counter-reports/upload/provider/" + PROVIDER_ID)
             .then()
             .statusCode(200)
@@ -623,10 +620,10 @@ private CounterReportDocument createReport(
     compareCOP5Reports(actualReports, expectedReports, 1);
     compareCOP5Reports(actualReports, expectedReports, 2);
 
-    String reportDocFromJSON = createReportFromJson(FILE_REPORT_MULTI_COP5);
+    CounterReportDocument reportDocFromJSON = createReportFromJson(FILE_REPORT_MULTI_COP5);
     given()
         .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
-        .body(IOUtils.toInputStream(reportDocFromJSON, StandardCharsets.UTF_8))
+        .body(reportDocFromJSON)
         .post("/counter-reports/upload/provider/" + PROVIDER_ID)
         .then()
         .statusCode(500)
@@ -647,11 +644,11 @@ private CounterReportDocument createReport(
     String csvString = Counter5Utils.toCSV(report);
     assertThat(csvString).isNotNull();
 
-    String reportDoc = createReport(csvString, "text/csv", true, "Edit Reason");
+    CounterReportDocument reportDoc = createReport(csvString, "text/csv", true, "Edit Reason");
     String createdIds =
         given()
             .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
-            .body(IOUtils.toInputStream(reportDoc, StandardCharsets.UTF_8))
+            .body(reportDoc)
             .post("/counter-reports/upload/provider/" + PROVIDER_ID)
             .then()
             .statusCode(200)
@@ -672,10 +669,13 @@ private CounterReportDocument createReport(
 
     // check content here
     assertThat(report).isNotNull();
-    reports.getCounterReports().forEach(counterReport -> {
-      assertThat(counterReport.getReportEditedManually()).isTrue();
-      assertThat(counterReport.getEditReason()).isEqualTo("Edit Reason");
-    });
+    reports
+        .getCounterReports()
+        .forEach(
+            counterReport -> {
+              assertThat(counterReport.getReportEditedManually()).isTrue();
+              assertThat(counterReport.getEditReason()).isEqualTo("Edit Reason");
+            });
   }
 
   private void compareCOP5Reports(
@@ -752,10 +752,10 @@ private CounterReportDocument createReport(
 
   @Test
   public void testProviderNotFound() throws IOException {
-    String reportDoc = createReportFromJson(FILE_REPORT_OK);
+    CounterReportDocument reportDoc = createReportFromJson(FILE_REPORT_OK);
     given()
         .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
-        .body(IOUtils.toInputStream(reportDoc, StandardCharsets.UTF_8))
+        .body(reportDoc)
         .post("/counter-reports/upload/provider/" + PROVIDER_ID2)
         .then()
         .statusCode(500)

--- a/mod-erm-usage-server/src/test/java/org/folio/rest/impl/CounterReportUploadIT.java
+++ b/mod-erm-usage-server/src/test/java/org/folio/rest/impl/CounterReportUploadIT.java
@@ -244,7 +244,7 @@ public class CounterReportUploadIT {
     String report = createReportFromJson(FILE_REPORT_OK);
     String savedReportId =
         given()
-            .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
+            .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
             .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
             .post("/counter-reports/upload/provider/" + PROVIDER_ID)
             .then()
@@ -272,7 +272,7 @@ public class CounterReportUploadIT {
     String report = createReport(FILE_REPORT_OK, "application/json", true, "Edit Reason");
     String savedReportId =
         given()
-            .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
+            .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
             .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
             .post("/counter-reports/upload/provider/" + PROVIDER_ID)
             .then()
@@ -298,11 +298,11 @@ public class CounterReportUploadIT {
   public void testReportR4UnsupportedReport() throws IOException {
     String report = createReportFromJson(FILE_REPORT_UNSUPPORTED);
     given()
-        .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
+        .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
         .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
         .post("/counter-reports/upload/provider/" + PROVIDER_ID)
         .then()
-        .statusCode(500)
+        .statusCode(400)
         .body(containsString("Unsupported report"));
   }
 
@@ -311,7 +311,7 @@ public class CounterReportUploadIT {
     String report = createReportFromJson(FILE_REPORT_OK);
     String savedReportId =
         given()
-            .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
+            .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
             .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
             .queryParam("overwrite", true)
             .post("/counter-reports/upload/provider/" + PROVIDER_ID)
@@ -323,7 +323,7 @@ public class CounterReportUploadIT {
 
     String overwriteReportId =
         given()
-            .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
+            .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
             .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
             .queryParam("overwrite", true)
             .post("/counter-reports/upload/provider/" + PROVIDER_ID)
@@ -340,7 +340,7 @@ public class CounterReportUploadIT {
   public void testReportR4OkOverwriteFalse() throws IOException {
     String report = createReportFromJson(FILE_REPORT_OK);
     given()
-        .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
+        .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
         .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
         .queryParam("overwrite", false)
         .post("/counter-reports/upload/provider/" + PROVIDER_ID)
@@ -348,7 +348,7 @@ public class CounterReportUploadIT {
         .statusCode(200);
 
     given()
-        .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
+        .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
         .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
         .queryParam("overwrite", false)
         .post("/counter-reports/upload/provider/" + PROVIDER_ID)
@@ -363,7 +363,7 @@ public class CounterReportUploadIT {
     String report = createReportFromJson(FILE_REPORT_NSS_OK);
     String savedReportId =
         given()
-            .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
+            .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
             .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
             .post("/counter-reports/upload/provider/" + PROVIDER_ID)
             .then()
@@ -395,7 +395,7 @@ public class CounterReportUploadIT {
     String reportDoc = createReportFromJson(FILE_REPORT5_OK);
     String savedReportId =
         given()
-            .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
+            .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
             .body(IOUtils.toInputStream(reportDoc, StandardCharsets.UTF_8))
             .post("/counter-reports/upload/provider/" + PROVIDER_ID)
             .then()
@@ -424,11 +424,11 @@ public class CounterReportUploadIT {
   public void testReportInvalidContent() throws IOException {
     String report = createReportFromJson(FILE_NO_REPORT);
     given()
-        .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
+        .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
         .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
         .post("/counter-reports/upload/provider/" + PROVIDER_ID)
         .then()
-        .statusCode(500)
+        .statusCode(400)
         .body(containsString("Wrong format"));
   }
 
@@ -437,7 +437,7 @@ public class CounterReportUploadIT {
     String report = createReportFromJson(FILE_REPORT_MULTI_COP4);
     String createdIds =
         given()
-            .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
+            .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
             .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
             .post("/counter-reports/upload/provider/" + PROVIDER_ID)
             .then()
@@ -456,7 +456,7 @@ public class CounterReportUploadIT {
         .containsExactlyInAnyOrder(createdIds.split(","));
 
     given()
-        .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
+        .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
         .body(IOUtils.toInputStream(report, StandardCharsets.UTF_8))
         .post("/counter-reports/upload/provider/" + PROVIDER_ID)
         .then()
@@ -486,7 +486,7 @@ public class CounterReportUploadIT {
     String reportDocument = createReport(csvString, "text/csv", false, null);
     String createdIds =
         given()
-            .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
+            .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
             .body(IOUtils.toInputStream(reportDocument, StandardCharsets.UTF_8))
             .post("/counter-reports/upload/provider/" + PROVIDER_ID)
             .then()
@@ -535,7 +535,7 @@ public class CounterReportUploadIT {
 
     String reportDocumentCOP4 = createReportFromJson(FILE_REPORT_MULTI_COP4);
     given()
-        .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
+        .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
         .body(IOUtils.toInputStream(reportDocumentCOP4, StandardCharsets.UTF_8))
         .post("/counter-reports/upload/provider/" + PROVIDER_ID)
         .then()
@@ -550,7 +550,7 @@ public class CounterReportUploadIT {
     String reportDoc = createReportFromJson(FILE_REPORT_MULTI_COP5);
     String createdIds =
         given()
-            .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
+            .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
             .body(IOUtils.toInputStream(reportDoc, StandardCharsets.UTF_8))
             .post("/counter-reports/upload/provider/" + PROVIDER_ID)
             .then()
@@ -569,7 +569,7 @@ public class CounterReportUploadIT {
         .containsExactlyInAnyOrder(createdIds.split(","));
 
     given()
-        .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
+        .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
         .body(IOUtils.toInputStream(reportDoc, StandardCharsets.UTF_8))
         .post("/counter-reports/upload/provider/" + PROVIDER_ID)
         .then()
@@ -593,7 +593,7 @@ public class CounterReportUploadIT {
     String reportDoc = createReport(csvString, "text/csv", false, null);
     String createdIds =
         given()
-            .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
+            .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
             .body(IOUtils.toInputStream(reportDoc, StandardCharsets.UTF_8))
             .post("/counter-reports/upload/provider/" + PROVIDER_ID)
             .then()
@@ -631,7 +631,7 @@ public class CounterReportUploadIT {
 
     String reportDocFromJSON = createReportFromJson(FILE_REPORT_MULTI_COP5);
     given()
-        .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
+        .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
         .body(IOUtils.toInputStream(reportDocFromJSON, StandardCharsets.UTF_8))
         .post("/counter-reports/upload/provider/" + PROVIDER_ID)
         .then()
@@ -656,7 +656,7 @@ public class CounterReportUploadIT {
     String reportDoc = createReport(csvString, "text/csv", true, "Edit Reason");
     String createdIds =
         given()
-            .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
+            .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
             .body(IOUtils.toInputStream(reportDoc, StandardCharsets.UTF_8))
             .post("/counter-reports/upload/provider/" + PROVIDER_ID)
             .then()
@@ -760,7 +760,7 @@ public class CounterReportUploadIT {
   public void testProviderNotFound() throws IOException {
     String reportDoc = createReportFromJson(FILE_REPORT_OK);
     given()
-        .header(HttpHeaders.CONTENT_TYPE, ContentType.BINARY)
+        .header(HttpHeaders.CONTENT_TYPE, ContentType.JSON)
         .body(IOUtils.toInputStream(reportDoc, StandardCharsets.UTF_8))
         .post("/counter-reports/upload/provider/" + PROVIDER_ID2)
         .then()

--- a/mod-erm-usage-server/src/test/java/org/folio/rest/impl/CounterReportUploadIT.java
+++ b/mod-erm-usage-server/src/test/java/org/folio/rest/impl/CounterReportUploadIT.java
@@ -222,21 +222,15 @@ public class CounterReportUploadIT {
     return createReport(fileAsString, mimeType, reportEditedManually, editReason);
   }
 
-  private String createReport(String string, String mimeType, Boolean reportEditedManually,
-      String editReason)
-      throws IOException {
+private CounterReportDocument createReport(
+      String string, String mimeType, Boolean reportEditedManually, String editReason) {
     String fileAsBytes = Base64.getEncoder().encodeToString(string.getBytes());
     Contents content = new Contents().withData("data:" + mimeType + " ;base64," + fileAsBytes);
     ReportMetadata metadata = new ReportMetadata().withReportEditedManually(reportEditedManually);
     if (editReason != null && reportEditedManually) {
       metadata.setEditReason(editReason);
     }
-    CounterReportDocument document = new CounterReportDocument()
-        .withReportMetadata(metadata)
-        .withContents(content);
-
-    ObjectMapper objectMapper = new ObjectMapper();
-    return objectMapper.writeValueAsString(document);
+    return new CounterReportDocument().withReportMetadata(metadata).withContents(content);
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.olf</groupId>
   <artifactId>mod-erm-usage</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>4.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <licenses>

--- a/ramls/counterreports.raml
+++ b/ramls/counterreports.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Counter Reports
-version: v2.1
+version: v3.0
 baseUri: http://localhost/mod-erm-usage
 
 documentation:

--- a/ramls/counterreports.raml
+++ b/ramls/counterreports.raml
@@ -8,6 +8,7 @@ documentation:
     content: This documents the API calls that can be made to query and manage counter reports
 
 types:
+  counterReportDocument: !include ./schemas/counterreport_document.json
   counterReport: !include ./schemas/counterreport.json
   counterReports: !include ./schemas/counterreports.json
   counterReportsSorted: !include ./schemas/counterreports_sorted.json
@@ -145,6 +146,9 @@ resourceTypes:
         application/octet-stream:
       responses:
         200:
+          body:
+            text/plain:
+        400:
           body:
             text/plain:
         404:

--- a/ramls/counterreports.raml
+++ b/ramls/counterreports.raml
@@ -142,8 +142,10 @@ resourceTypes:
           description: Overwrite existing reports?
           type: boolean
           default: false
+      is: [validate]
       body:
-        application/octet-stream:
+        application/json:
+          schema: counterReportDocument
       responses:
         200:
           body:

--- a/ramls/schemas/counterreport_document.json
+++ b/ramls/schemas/counterreport_document.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Document containing a base64 encoded counter report with additional metadata",
+  "type": "object",
+  "properties": {
+    "reportMetadata": {
+      "description": "Report metadata",
+      "type": "object",
+      "$ref": "report_metadata.json"
+    },
+    "contents": {
+      "description": "Base64 encoded report file",
+      "type": "object",
+      "$ref": "report_data.json"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "reportMetadata",
+    "contents"
+  ]
+}

--- a/ramls/schemas/report_data.json
+++ b/ramls/schemas/report_data.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Object with base64 encoded report file",
+  "type": "object",
+  "properties": {
+    "data": {
+      "description": "Base64 encoded report file",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "data"
+  ]
+}

--- a/ramls/schemas/report_metadata.json
+++ b/ramls/schemas/report_metadata.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Report metadata",
+  "type": "object",
+  "properties": {
+    "reportEditedManually": {
+      "description": "Flag if report was edited manually",
+      "type": "boolean"
+    },
+    "editReason": {
+      "description": "Reason why report was edited",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "reportEditedManually"
+  ]
+}


### PR DESCRIPTION
## Ticket
https://issues.folio.org/browse/MODEUS-104

## What?
Restructured body/payload for uploading counter-reports. The [URL-encoded](https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsDataURL) counter-report is included in a json document with additional metadata.

## Why?
Currently, when manually uploading a counter-report the report's json, xml or csv is sent as the request's payload.
With this solution we can't specify additional attributes as needed for [UIEUS-223](https://issues.folio.org/browse/UIEUS-223).

## How?
This PR restructures the payload of a POST request to `/counter-reports/upload/provider/{id}`. The report is included URL-encoded into a JSON document with additional metadata.

A json POSTed to `/counter-reports/upload/provider/{id}` may look like the following:
```
{
  "reportMetadata": {
    "reportEditedManually": true,
    "editReason": "FOOBAAAAAR"
  },
  "contents": {
    "data": "data:application/json;base64,foobarbase64"
  }
}
```
Here, `contents -> data` holds the encoded report.

When the posted stream is complete, the report is decoded and processed as before this PR. Hence, it is possible to include multiple months into the report.
