### PR TITLE
MODEUS-111-delete-multiple-reports

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -125,7 +125,7 @@
     },
     {
       "id": "counter-reports",
-      "version": "3.0",
+      "version": "3.1",
       "handlers": [
         {
           "methods": [
@@ -234,6 +234,15 @@
           "permissionsRequired": [
             "counterreports.collection.get"
           ]
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "pathPattern": "/counter-reports/reports/delete",
+          "permissionsRequired": [
+            "counterreports.item.delete"
+          ]
         }
       ]
     },
@@ -325,14 +334,19 @@
       "id": "_tenant",
       "version": "2.0",
       "interfaceType": "system",
-      "handlers" : [
+      "handlers": [
         {
-          "methods" : [ "POST" ],
-          "pathPattern" : "/_/tenant"
+          "methods": [
+            "POST"
+          ],
+          "pathPattern": "/_/tenant"
         },
         {
-          "methods" : [ "GET", "DELETE" ],
-          "pathPattern" : "/_/tenant/{id}"
+          "methods": [
+            "GET",
+            "DELETE"
+          ],
+          "pathPattern": "/_/tenant/{id}"
         }
       ]
     }

--- a/ramls/counterreports.raml
+++ b/ramls/counterreports.raml
@@ -185,3 +185,20 @@ resourceTypes:
         500:
           body:
             text/plain:
+  /reports/delete:
+    post:
+      description: Delete multiple counter reports
+      body:
+        application/json:
+          type: array
+          items:
+            type: string
+          example: ["e05e1089-7810-4f07-844f-5c4b8db7395e", "ed05a906-c36e-4c3b-a37d-2a52ca8580da"]
+      responses:
+        204:
+        400:
+          body:
+            text/plain:
+        500:
+          body:
+            text/plain:


### PR DESCRIPTION
This PR adds the `/counter-reports/reports/delete` endpoint.
It excepts POST requests with a JSON array with UUIDs as body.
Provided UUIDs will be deleted from the `counter_reports` table in a single SQL statement.

A request returns
* `204` if the SQL query is successfully executed, 
* `500` if the SQL query fails and 
* `400` if provided request body is faulty.