### PR TITLE
MODEUS-126

### DIFF
--- a/mod-erm-usage-server/src/main/java/org/folio/rest/util/PgHelper.java
+++ b/mod-erm-usage-server/src/main/java/org/folio/rest/util/PgHelper.java
@@ -257,7 +257,8 @@ public class PgHelper {
   public static Future<ErrorCodes> getErrorCodes(
       Context vertxContext, Map<String, String> okapiHeaders) {
     String query =
-        "SELECT DISTINCT(SUBSTRING(jsonb->>'failedReason','Number=([0-9]{1,4})')) FROM counter_reports WHERE jsonb->>'failedReason' IS NOT NULL";
+        "SELECT DISTINCT(SUBSTRING(jsonb->>'failedReason','(?:Number=|\"Code\": ?)([0-9]{1,4})'))"
+            + " FROM counter_reports WHERE jsonb->>'failedReason' IS NOT NULL";
     Promise<ErrorCodes> result = Promise.promise();
     PgUtil.postgresClient(vertxContext, okapiHeaders)
         .select(

--- a/mod-erm-usage-server/src/main/resources/templates/db_scripts/counterreports_triggers.sql
+++ b/mod-erm-usage-server/src/main/resources/templates/db_scripts/counterreports_triggers.sql
@@ -20,7 +20,7 @@ CREATE OR REPLACE FUNCTION udp_report_errors(providerId TEXT) RETURNS jsonb AS $
     AS error
     FROM (
       SELECT
-        DISTINCT(SUBSTRING(jsonb->>'failedReason','Number=([0-9]{1,4})')) as error_code,
+        DISTINCT(SUBSTRING(jsonb->>'failedReason','(?:Number=|"Code": ?)([0-9]{1,4})')) as error_code,
         COUNT(jsonb->>'failedReason') as number_failed
       FROM  	counter_reports
       WHERE		jsonb->>'providerId'=$1 AND jsonb->>'failedReason' IS NOT NULL

--- a/mod-erm-usage-server/src/main/resources/templates/db_scripts/custom_indexes.sql
+++ b/mod-erm-usage-server/src/main/resources/templates/db_scripts/custom_indexes.sql
@@ -2,7 +2,7 @@ CREATE INDEX IF NOT EXISTS counter_reports_custom_getcsv_idx ON counter_reports
   USING btree ((jsonb ->> 'providerId'), (jsonb ->> 'reportName'), (jsonb ->> 'release'),
     (jsonb ->> 'yearMonth'));
 CREATE INDEX IF NOT EXISTS counter_reports_custom_errorcodes_idx ON counter_reports
-  USING btree(SUBSTRING(jsonb->>'failedReason','Number=([0-9]{1,4})'))
+  USING btree(SUBSTRING(jsonb->>'failedReason','(?:Number=|"Code": ?)([0-9]{1,4})'))
   WHERE jsonb ->> 'failedReason' IS NOT NULL;
 CREATE INDEX IF NOT EXISTS usage_data_providers_custom_aggregatorid_idx ON usage_data_providers
   USING btree ((jsonb->'harvestingConfig'->'aggregator'->>'id'));


### PR DESCRIPTION
Updates the regex expressions used to extract SUSHI error codes from a reports `failedReason` attribute from `Number=([0-9]{1,4})` to `(?:Number=|\"Code\": ?)([0-9]{1,4})`, to account for the format of Counter5 error messages.