### PR TITLE
APPDESCRIP-28: update erm-usage/files interface id to be valid for Eureka platform

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -307,7 +307,7 @@
       ]
     },
     {
-      "id": "erm-usage/files",
+      "id": "erm-usage-files",
       "version": "1.0",
       "handlers": [
         {

--- a/mod-erm-usage-client/pom.xml
+++ b/mod-erm-usage-client/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.olf</groupId>
     <artifactId>mod-erm-usage</artifactId>
-    <version>4.9.0-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/mod-erm-usage-server/pom.xml
+++ b/mod-erm-usage-server/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.olf</groupId>
     <artifactId>mod-erm-usage</artifactId>
-    <version>4.9.0-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.olf</groupId>
   <artifactId>mod-erm-usage</artifactId>
-  <version>4.9.0-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <licenses>


### PR DESCRIPTION
[APPDESCRIP-28](https://folio-org.atlassian.net/browse/APPDESCRIP-28)

**Related PR:** https://github.com/folio-org/app-erm-usage/pull/1

**Purpose:** update `erm-usage/files` interface id to be valid for Eureka platform