### PR TITLE
[MODEUS-179] Change 'reportRelease' data type in 'udprovider' schema to string

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "usage-data-providers",
-      "version": "2.8",
+      "version": "3.0",
       "handlers": [
         {
           "methods": [

--- a/mod-erm-usage-server/src/main/java/org/folio/rest/util/ExportObject.java
+++ b/mod-erm-usage-server/src/main/java/org/folio/rest/util/ExportObject.java
@@ -91,7 +91,7 @@ public class ExportObject {
     this.providerName = provider.getLabel();
     this.harvestingStatus =
         Objects.toString(provider.getHarvestingConfig().getHarvestingStatus(), null);
-    this.reportRelease = Objects.toString(provider.getHarvestingConfig().getReportRelease(), null);
+    this.reportRelease = provider.getHarvestingConfig().getReportRelease();
     this.requestedReports = String.join(", ", provider.getHarvestingConfig().getRequestedReports());
     this.customerId = provider.getSushiCredentials().getCustomerId();
     this.requestorId = provider.getSushiCredentials().getRequestorId();

--- a/mod-erm-usage-server/src/main/resources/templates/db_scripts/migration/5.0.0/migrate_udp_schema.sql
+++ b/mod-erm-usage-server/src/main/resources/templates/db_scripts/migration/5.0.0/migrate_udp_schema.sql
@@ -1,0 +1,11 @@
+-- Replace number values stored in harvestingConfig.reportRelease with a string value
+DO $$
+BEGIN
+    UPDATE ${myuniversity}_${mymodule}.usage_data_providers
+    SET jsonb = jsonb_set(
+        jsonb,
+        '{harvestingConfig,reportRelease}',
+        to_jsonb((jsonb->'harvestingConfig'->>'reportRelease'))
+    )
+    WHERE jsonb_typeof(jsonb->'harvestingConfig'->'reportRelease') = 'number';
+END $$;

--- a/mod-erm-usage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-erm-usage-server/src/main/resources/templates/db_scripts/schema.json
@@ -1,6 +1,11 @@
 {
   "scripts": [
     {
+      "run": "after",
+      "snippetPath": "migration/5.0.0/migrate_udp_schema.sql",
+      "fromModuleVersion": "mod-erm-usage-5.0.0"
+    },
+    {
       "run": "before",
       "snippetPath": "migration/4.8.0/migrate_files_table.sql",
       "fromModuleVersion": "mod-erm-usage-4.8.0"

--- a/mod-erm-usage-server/src/test/java/org/folio/rest/impl2/CounterReportExportStandardViewIT.java
+++ b/mod-erm-usage-server/src/test/java/org/folio/rest/impl2/CounterReportExportStandardViewIT.java
@@ -179,7 +179,7 @@ public class CounterReportExportStandardViewIT {
         .withLabel("TestProvider")
         .withHarvestingConfig(
             new HarvestingConfig()
-                .withReportRelease(5)
+                .withReportRelease("5")
                 .withHarvestingStart("2021-01")
                 .withHarvestingStatus(HarvestingStatus.INACTIVE)
                 .withHarvestVia(HarvestVia.SUSHI)

--- a/mod-erm-usage-server/src/test/resources/exportcredentials/providers.json
+++ b/mod-erm-usage-server/src/test/resources/exportcredentials/providers.json
@@ -8,7 +8,7 @@
         "aggregator": {
           "id": "0adec15b-8230-48fe-b4df-87106c5dc36e"
         },
-        "reportRelease": 4,
+        "reportRelease": "4",
         "requestedReports": [
           "JR1",
           "JR4"
@@ -30,7 +30,7 @@
         "aggregator": {
           "id": "0adec15b-8230-48fe-b4df-87106c5dc36e"
         },
-        "reportRelease": 4,
+        "reportRelease": "4",
         "requestedReports": [
           "JR1",
           "JR4"
@@ -52,7 +52,7 @@
         "aggregator": {
           "id": "0adec15b-8230-48fe-b4df-87106c5dc36e"
         },
-        "reportRelease": 4,
+        "reportRelease": "4",
         "requestedReports": [
           "JR1",
           "JR4"
@@ -74,7 +74,7 @@
         "aggregator": {
           "id": "fe965f77-d9d1-4127-b057-3c76b56b3e6a"
         },
-        "reportRelease": 4,
+        "reportRelease": "4",
         "requestedReports": [
           "JR1",
           "JR4"

--- a/mod-erm-usage-server/src/test/resources/fileupload/provider.json
+++ b/mod-erm-usage-server/src/test/resources/fileupload/provider.json
@@ -8,7 +8,7 @@
       "serviceType": "cs41",
       "serviceUrl": "http://www.jstor.org/sushi"
     },
-    "reportRelease": 4,
+    "reportRelease": "4",
     "requestedReports": [
       "JR1"
     ],

--- a/ramls/examples/udproviders.sample
+++ b/ramls/examples/udproviders.sample
@@ -8,7 +8,7 @@
       "serviceType": "cs41",
       "serviceUrl": "http://myvendor.com"
     },
-    "reportRelease": 4,
+    "reportRelease": "4",
     "requestedReports": [
       "JR1",
       "TR1"

--- a/ramls/examples/udproviders2.sample
+++ b/ramls/examples/udproviders2.sample
@@ -12,7 +12,7 @@
       "id": "4c66b956-23a8-4418-aef6-1c35dcdaccc4",
       "vendorCode": "ACMDL"
     },
-    "reportRelease": 4,
+    "reportRelease": "4",
     "requestedReports": [
       "JR1",
       "TR1"

--- a/ramls/examples/udproviders_collection.sample
+++ b/ramls/examples/udproviders_collection.sample
@@ -14,7 +14,7 @@
           "id": "4c66b956-23a8-4418-aef6-1c35dcdaccc4",
           "vendorCode": "ACMDL"
         },
-        "reportRelease": 4,
+        "reportRelease": "4",
         "requestedReports": [
           "JR1",
           "TR1"
@@ -45,7 +45,7 @@
           "id": "4c66b956-23a8-4418-aef6-1c35dcdaccc4",
           "vendorCode": "ACMDL"
         },
-        "reportRelease": 4,
+        "reportRelease": "4",
         "requestedReports": [
           "JR1",
           "TR1"

--- a/ramls/schemas/udprovider.json
+++ b/ramls/schemas/udprovider.json
@@ -71,7 +71,7 @@
           ]
         },
         "reportRelease": {
-          "type": "integer",
+          "type": "string",
           "description": "Specifies the counter report version."
         },
         "requestedReports": {

--- a/sample-data/usage-data-providers/ACSO.json
+++ b/sample-data/usage-data-providers/ACSO.json
@@ -8,7 +8,7 @@
       "id": "5b6ba83e-d7e5-414e-ba7b-134749c0d950",
       "vendorCode": "ACSO"
     },
-    "reportRelease": 5,
+    "reportRelease": "5",
     "requestedReports": [
       "IR",
       "TR"

--- a/sample-data/usage-data-providers/ALEXS.json
+++ b/sample-data/usage-data-providers/ALEXS.json
@@ -8,7 +8,7 @@
       "id": "5b6ba83e-d7e5-414e-ba7b-134749c0d950",
       "vendorCode": "ALEXS"
     },
-    "reportRelease": 4,
+    "reportRelease": "4",
     "requestedReports": [
       "JR5",
       "JR1"

--- a/sample-data/usage-data-providers/GOBI.json
+++ b/sample-data/usage-data-providers/GOBI.json
@@ -8,7 +8,7 @@
       "serviceType": "cs41",
       "serviceUrl": "http://usage.gobi.com/SushiServer"
     },
-    "reportRelease": 4,
+    "reportRelease": "4",
     "requestedReports": [
       "DR1"
     ],

--- a/sample-data/usage-data-providers/HARRA.json
+++ b/sample-data/usage-data-providers/HARRA.json
@@ -8,7 +8,7 @@
       "serviceType": "cs41",
       "serviceUrl": "https://counter.harra.de/counter/webservice/sushi"
     },
-    "reportRelease": 4,
+    "reportRelease": "4",
     "requestedReports": [
       "JR1"
     ],


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODEUS-179

Updates json schema for `udprovider`.

Module major version has already been increased in a prior PR.

Merge needs to be coordinated with:

- https://github.com/folio-org/ui-erm-usage/pull/489
- https://github.com/folio-org/mod-erm-usage-harvester/pull/179
- https://github.com/folio-org/mod-eusage-reports/pull/192