### PR TITLE
[MODEUS-188] Update `createDownloadResponseByReportVersion` method to support COUNTER release 5.1

### DIFF
--- a/mod-erm-usage-server/src/main/java/org/folio/rest/util/ReportExportHelper.java
+++ b/mod-erm-usage-server/src/main/java/org/folio/rest/util/ReportExportHelper.java
@@ -92,19 +92,16 @@ public class ReportExportHelper {
 
   public static Response createDownloadResponseByReportVersion(CounterReport report) {
     if (report.getRelease().equals("4")) {
-      String xmlReport = Counter4Utils.toXML(Json.encode(report.getReport()));
-      return Optional.ofNullable(xmlReport)
-          .map(r -> GetCounterReportsDownloadByIdResponse.respond200WithApplicationXml(xmlReport))
+      return Optional.ofNullable(report.getReport())
+          .map(Json::encode)
+          .map(Counter4Utils::toXML)
+          .map(GetCounterReportsDownloadByIdResponse::respond200WithApplicationXml)
           .orElse(null);
-    } else if (report.getRelease().equals("5")) {
-      String jsonReport = Json.encode(report.getReport());
-      return Optional.ofNullable(jsonReport)
-          .map(r -> GetCounterReportsDownloadByIdResponse.respond200WithApplicationJson(jsonReport))
-          .orElse(null);
-    } else {
-      return GetCounterReportsDownloadByIdResponse.respond500WithTextPlain(
-          String.format("Unsupported report version '%s'", report.getRelease()));
     }
+    return Optional.ofNullable(report.getReport())
+        .map(Json::encode)
+        .map(GetCounterReportsDownloadByIdResponse::respond200WithApplicationJson)
+        .orElse(null);
   }
 
   private static Optional<String> csvMapper(CounterReport cr) {

--- a/mod-erm-usage-server/src/test/java/org/folio/rest/impl2/CounterReportIT.java
+++ b/mod-erm-usage-server/src/test/java/org/folio/rest/impl2/CounterReportIT.java
@@ -177,28 +177,6 @@ public class CounterReportIT {
   }
 
   @Test
-  public void testGetCounterReportsDownloadByIdInvalidVersion() {
-    given(counterReportsReqSpec)
-        .body(Json.decodeValue(Json.encode(report), CounterReport.class).withRelease("1"))
-        .post()
-        .then()
-        .statusCode(201);
-
-    String body =
-        given(counterReportsReqSpec)
-            .pathParam("id", report.getId())
-            .get(PATH_DOWNLOAD)
-            .then()
-            .contentType(ContentType.TEXT)
-            .statusCode(500)
-            .extract()
-            .body()
-            .asString();
-
-    assertThat(body).contains("Unsupported", "version", "'1'");
-  }
-
-  @Test
   public void testDeleteMultipleReportsInvalidBody() {
     given(reportsDeleteReqSpec).post().then().statusCode(400);
     given(reportsDeleteReqSpec).body("{}").post().then().statusCode(400);

--- a/mod-erm-usage-server/src/test/java/org/folio/rest/util/ReportExportHelperTest.java
+++ b/mod-erm-usage-server/src/test/java/org/folio/rest/util/ReportExportHelperTest.java
@@ -2,9 +2,14 @@ package org.folio.rest.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.rest.util.ReportExportHelper.CREATED_BY_SUFFIX;
+import static org.folio.rest.util.ReportExportHelper.createDownloadResponseByReportVersion;
 import static org.folio.rest.util.ReportExportHelper.replaceCreatedBy;
 
+import javax.ws.rs.core.MediaType;
+import org.folio.rest.jaxrs.model.CounterReport;
+import org.folio.rest.jaxrs.model.Report;
 import org.junit.Test;
+import org.olf.erm.usage.counter41.Counter4Utils;
 
 public class ReportExportHelperTest {
 
@@ -14,8 +19,8 @@ public class ReportExportHelperTest {
         .isEqualTo("Created_By,Provider " + CREATED_BY_SUFFIX);
     assertThat(replaceCreatedBy("\n\nCreated_By,Provider\n"))
         .isEqualTo("\n\nCreated_By,Provider " + CREATED_BY_SUFFIX + "\n");
-    assertThat(replaceCreatedBy("Created_By,Provider " + CREATED_BY_SUFFIX + ""))
-        .isEqualTo("Created_By,Provider " + CREATED_BY_SUFFIX + "");
+    assertThat(replaceCreatedBy("Created_By,Provider " + CREATED_BY_SUFFIX))
+        .isEqualTo("Created_By,Provider " + CREATED_BY_SUFFIX);
     assertThat(replaceCreatedBy("Created_By,\"Provider, named abc\""))
         .isEqualTo("Created_By,\"Provider, named abc " + CREATED_BY_SUFFIX + "\"");
     assertThat(replaceCreatedBy("Created_By,\"Provider, named abc " + CREATED_BY_SUFFIX + "\""))
@@ -29,5 +34,36 @@ public class ReportExportHelperTest {
     assertThat(replaceCreatedBy("Created_By,")).isEqualTo("Created_By, " + CREATED_BY_SUFFIX);
     assertThat(replaceCreatedBy("Created_by,")).isEqualTo("Created_by,");
     assertThat(replaceCreatedBy(null)).isNull();
+  }
+
+  @Test
+  public void testCreateDownloadResponseByReportVersion() {
+    assertThat(
+            createDownloadResponseByReportVersion(
+                new CounterReport().withRelease("4").withReport(new Report())))
+        .satisfies(
+            response -> {
+              assertThat(response.getMediaType()).isEqualTo(MediaType.APPLICATION_XML_TYPE);
+              assertThat(response.getEntity()).isEqualTo(Counter4Utils.toXML("{}"));
+            });
+
+    assertThat(
+            createDownloadResponseByReportVersion(
+                new CounterReport().withRelease("4").withReport(null)))
+        .isNull();
+
+    assertThat(
+            createDownloadResponseByReportVersion(
+                new CounterReport().withRelease("5").withReport(new Report())))
+        .satisfies(
+            response -> {
+              assertThat(response.getMediaType()).isEqualTo(MediaType.APPLICATION_JSON_TYPE);
+              assertThat(response.getEntity()).isEqualTo("{}");
+            });
+
+    assertThat(
+            createDownloadResponseByReportVersion(
+                new CounterReport().withRelease("5").withReport(null)))
+        .isNull();
   }
 }


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODEUS-188

* Update `createDownloadResponseByReportVersion` in `ReportExportHelper`