### PR TITLE
Add code formatting section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,14 @@
 # Contribution guidelines
 
-Guidelines for Contributing Code:
+## Guidelines for Contributing Code:
+
 [dev.folio.org/guidelines/contributing](https://dev.folio.org/guidelines/contributing)
+
+## Code Formatting
+
+This project follows the [Google Java Style](https://google.github.io/styleguide/javaguide.html)
+for code formatting. To ensure consistency in the codebase, please format your code according to
+these guidelines before submitting a pull request.
+
+Use `mvn spotless:check` to check for formatting violations and `mvn spotless:apply` to
+automatically fix them.

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,8 @@
     <aspectj-maven-plugin.version>1.14</aspectj-maven-plugin.version>
     <log4j.version>2.23.0</log4j.version>
     <erm.usage.counter.version>4.1.0</erm.usage.counter.version>
+    <spotless.version>2.43.0</spotless.version>
+    <google-java-format.version>1.24.0</google-java-format.version>
 
     <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
   </properties>
@@ -140,6 +142,22 @@
     </pluginManagement>
 
     <plugins>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>${spotless.version}</version>
+        <configuration>
+          <ratchetFrom>origin/master</ratchetFrom>
+          <java>
+            <googleJavaFormat>
+              <version>${google-java-format.version}</version>
+              <style>GOOGLE</style>
+              <reflowLongStrings>true</reflowLongStrings>
+              <formatJavadoc>true</formatJavadoc>
+            </googleJavaFormat>
+          </java>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.folio</groupId>
         <artifactId>folio-module-descriptor-validator</artifactId>


### PR DESCRIPTION
* Adds information about code formatting to `CONTRIBUTING.md`
* Adds `spotless-maven-plugin`
* Currently, the Jenkins pipeline does not support running the `spotless:check` goal during the verify phase (see [using-ratchetfrom-on-ci-systems](https://github.com/diffplug/spotless/tree/main/plugin-maven#using-ratchetfrom-on-ci-systems))