### PR TITLE
[MODEUS-219] Fix udp_report_releases to guarantee sorted array ordering

### DIFF
--- a/mod-erm-usage-server/src/main/resources/templates/db_scripts/counterreports_triggers.sql
+++ b/mod-erm-usage-server/src/main/resources/templates/db_scripts/counterreports_triggers.sql
@@ -40,10 +40,14 @@ $$ LANGUAGE sql;
 
 -- returns the counter report release versions of the usage data provider's counter reports
 CREATE OR REPLACE FUNCTION udp_report_releases(providerId TEXT) RETURNS jsonb AS $$
-  SELECT COALESCE(jsonb_agg(DISTINCT jsonb->>'release'), '[]'::jsonb)
-  FROM counter_reports
-  WHERE jsonb->>'providerId' = $1
-  ORDER BY 1;
+  SELECT COALESCE(json_agg(release)::jsonb, '[]'::jsonb)
+  FROM (
+    SELECT DISTINCT jsonb->>'release' AS release
+    FROM counter_reports
+    WHERE jsonb->>'providerId' = $1
+    ORDER BY 1
+  )
+  AS sub
 $$ LANGUAGE sql;
 
 -- function to update the usage data provider statistics


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODEUS-219

## Purpose

The `udp_report_releases` SQL function returns the `reportReleases` array in unspecified order. The function uses `jsonb_agg(DISTINCT ...)` with an `ORDER BY` clause at the query level, but since the query returns a single aggregated row, the `ORDER BY` has no effect on the array element ordering.

The PostgreSQL documentation states:

> The aggregate functions array_agg, json_agg, jsonb_agg, [...] produce meaningfully different result values depending on the order of the input values. This ordering is unspecified by default, but can be controlled by writing an ORDER BY clause within the aggregate call.

The [documentation on aggregate expressions](https://www.postgresql.org/docs/current/sql-expressions.html#SYNTAX-AGGREGATES) further clarifies that `DISTINCT` alone does not guarantee ordering - it only ensures each distinct value is processed once. To control ordering, an `ORDER BY` clause must be placed within the aggregate call itself:

```sql
aggregate_name (DISTINCT expression [ , ... ] [ order_by_clause ] )
```

The existing tests in `SQLTriggersIT` assert sorted order and currently pass, but only by coincidence - PostgreSQL's `DISTINCT` implementation happens to use sort-based deduplication, which is not a documented guarantee.

## Approach

Refactor `udp_report_releases` to use a subquery pattern, matching the approach already used by `udp_report_types` and `udp_report_errors` in the same file. This moves `DISTINCT` and `ORDER BY` into a subquery so that sorting occurs before aggregation, making the ordering explicit and reliable.

An alternative would be to use the inline `ORDER BY` within the aggregate call:

```sql
SELECT COALESCE(jsonb_agg(DISTINCT jsonb->>'release' ORDER BY jsonb->>'release'), '[]'::jsonb)
```

The subquery approach was chosen for consistency with the other functions in the same file.

## Related

folio-org/ui-erm-usage#609