### PR TITLE
Run Spotless on all files and bind check goal to verify phase

### DIFF
--- a/mod-erm-usage-server/src/main/java/org/folio/rest/util/ProcessorHelper.java
+++ b/mod-erm-usage-server/src/main/java/org/folio/rest/util/ProcessorHelper.java
@@ -108,8 +108,7 @@ public class ProcessorHelper {
     List<SUSHIReportHeaderReportAttributes> actualAttributes = header.getReportAttributes();
     if (!(actualAttributes != null
         && actualAttributes.size() == expectedAttributes.size()
-        && new HashSet<>(normalize(actualAttributes))
-            .containsAll(normalize(expectedAttributes)))) {
+        && new HashSet<>(normalize(actualAttributes)).containsAll(normalize(expectedAttributes)))) {
       throw new ReportUploadException(INVALID_REPORT_CONTENT, "Unsupported report attributes.");
     }
   }

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,6 @@
         <artifactId>spotless-maven-plugin</artifactId>
         <version>${spotless.version}</version>
         <configuration>
-          <ratchetFrom>origin/master</ratchetFrom>
           <java>
             <googleJavaFormat>
               <version>${google-java-format.version}</version>
@@ -187,6 +186,14 @@
             </googleJavaFormat>
           </java>
         </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>verify</phase>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.folio</groupId>


### PR DESCRIPTION
## Purpose

Checking code formatting is currently a manual effort that can be missed, as `spotless:check` is not bound to any lifecycle phase and therefore not executed during a regular Maven build or in CI.

## Approach

- Remove the `ratchetFrom` setting from the Spotless plugin configuration in `pom.xml` so all files are subject to formatting checks.
- Bind the `spotless:check` goal to the `verify` phase so `mvn verify` fails on formatting violations.
- Apply `spotless:apply` to the full codebase, fixing formatting in three files (`CS41ImplTest`, `ExtendedCounter50Client`, `TooManyRequestsException`).

This mimics the setup in mod-erm-usage-counter (folio-org/mod-erm-usage-counter#101, folio-org/mod-erm-usage-counter#102) and mod-erm-usage-harvester (folio-org/mod-erm-usage-harvester#222).