### PR TITLE
MODEUS-224: Remove version propery in RAML files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # 5.3.0 (IN PROGRESS)
 * [MODEUS-225](https://folio-org.atlassian.net/browse/MODEUS-225) Allow both registry domains for `Registry_Record` in COUNTER 5.1 report uploads
+* [MODEUS-224](https://folio-org.atlassian.net/browse/MODEUS-224) Remove optional `version` property from RAML files
 
 # 5.2.0
 * [MODEUS-204](https://folio-org.atlassian.net/browse/MODEUS-204) Add `status` field to UDP schema

--- a/ramls/aggregatorsettings.raml
+++ b/ramls/aggregatorsettings.raml
@@ -1,6 +1,5 @@
 #%RAML 1.0
 title: Aggregator Settings
-version: v1.2
 baseUri: http://localhost/mod-erm-usage
 
 documentation:

--- a/ramls/counterreports.raml
+++ b/ramls/counterreports.raml
@@ -1,6 +1,5 @@
 #%RAML 1.0
 title: Counter Reports
-version: v3.0
 baseUri: http://localhost/mod-erm-usage
 
 documentation:

--- a/ramls/customreports.raml
+++ b/ramls/customreports.raml
@@ -1,6 +1,5 @@
 #%RAML 1.0
 title: Custom Reports
-version: v1.1
 baseUri: http://localhost/mod-erm-usage
 
 documentation:

--- a/ramls/files.raml
+++ b/ramls/files.raml
@@ -1,6 +1,5 @@
 #%RAML 1.0
 title: File Storage of erm-usage module
-version: v1
 baseUri: http://localhost/mod-erm-usage
 
 documentation:

--- a/ramls/usagedataproviders.raml
+++ b/ramls/usagedataproviders.raml
@@ -1,6 +1,5 @@
 #%RAML 1.0
 title: Usage Data Providers
-version: v2.8
 baseUri: http://localhost/mod-erm-usage
 
 documentation:


### PR DESCRIPTION
[MODEUS-224](https://folio-org.atlassian.net/browse/MODEUS-224)


**Description**

In several FOLIO module repositories, the interface version declared in the `ModuleDescriptor-template.json` does not match the version declared in the corresponding RAML file(s).
Documentation accuracy — the RAML version is the source of truth for the API contract; a mismatch is confusing for anyone consulting the RAML as documentation.

- usage-data-providers 3.2 usagedataproviders.raml → v2.8
- aggregator-settings 2.0 aggregatorsettings.raml → v1.2
- counter-reports 5.0 counterreports.raml → v3.0
- custom-reports 2.0 customreports.raml → v1.1
- erm-usage-files 1.0 files.raml → v1

**Approach**

Remove version propery in these RAML files:
- usagedataproviders.raml 
- aggregatorsettings.raml 
- counterreports.raml 
- customreports.raml 
- files.raml

Checked Leipzig module repositories and created Jira issues for :
- https://folio-org.atlassian.net/browse/MODEUSHARV-171
- https://folio-org.atlassian.net/browse/MODIDM-31
- https://folio-org.atlassian.net/browse/UIFC-502